### PR TITLE
docs: update CLAUDE.md to remove outdated code fragments

### DIFF
--- a/.ai/agent-context.md
+++ b/.ai/agent-context.md
@@ -214,6 +214,7 @@ web/modules/contrib/proxy_block/
 The module includes composer and npm scripts for comprehensive code quality checks:
 
 #### PHP Code Quality
+
 ```bash
 # DDEV commands (when using DDEV local environment)
 ddev composer run-script lint:check
@@ -225,6 +226,7 @@ composer run-script lint:fix
 ```
 
 #### JavaScript/CSS/Spelling Code Quality
+
 ```bash
 # DDEV commands (when using DDEV local environment)
 ddev exec npm run check                    # Run all checks (JS, CSS, spelling)
@@ -260,7 +262,7 @@ composer run-script release
 ### Additional Development Tools
 
 - **PHPStan**: Static analysis configuration available in `phpstan.neon`
-- **PHPUnit**: Test configuration in `phpunit.xml.dist`  
+- **PHPUnit**: Test configuration in `phpunit.xml.dist`
 - **CSpell**: Spell checking configuration in `cspell.json`
 - **Semantic Release**: Automated releases via `release.config.cjs`
 - **ESLint/Prettier**: JavaScript code quality and formatting


### PR DESCRIPTION
## Summary

- Remove specific code snippets from CLAUDE.md that can become stale over time
- Replace code examples with references to actual source code locations (e.g., `src/Plugin/Block/ProxyBlock.php`)
- Add DDEV integration commands with standard alternatives for local development
- Update file structure documentation to reflect recent CI setup and tooling additions

## Motivation

Code fragments in documentation quickly become outdated as the actual implementation evolves. This change ensures the CLAUDE.md file provides guidance that stays current by referencing source code locations rather than duplicating implementation details.

## Changes Made

- **Dependency Injection**: Now references constructor in source file instead of showing code snippet
- **Render Pipeline**: Points to `build()` method implementation rather than showing pseudo-code
- **Cache Integration**: References `bubbleTargetBlockCacheMetadata()` method instead of showing implementation
- **Development Patterns**: Describes patterns and points to example locations rather than showing code
- **Commands**: Added DDEV commands as primary with standard alternatives
- **File Structure**: Updated to include recent additions like `phpstan.neon`, `cspell.json`, `release.config.cjs`

## Benefits

- Documentation won't become stale when code changes
- Developers get pointed to the actual implementation
- Maintains architectural context and development guidance
- Easier to maintain going forward