### PR TITLE
fix: Layout Builder context handling + split responsibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ phpunit.xml
 /.claude/settings.local.json
 /CLAUDE.local.md
 /.ai/agent-context.local.md
+.claude/plans
+.ai/task-manager

--- a/proxy_block.services.yml
+++ b/proxy_block.services.yml
@@ -2,7 +2,11 @@ services:
   _defaults:
     autowire: true
     autoconfigure: true
+  logger.channel.proxy_block:
+    parent: logger.channel_base
+    arguments: ['proxy_block']
   Drupal\proxy_block\Service\TargetBlockContextManager: {}
   Drupal\proxy_block\Service\TargetBlockFactory: {}
   Drupal\proxy_block\Service\TargetBlockFormProcessor: {}
   Drupal\proxy_block\Service\TargetBlockCacheManager: {}
+  Drupal\proxy_block\Service\ProxyBlockRenderer: {}

--- a/src/Plugin/Block/ProxyBlock.php
+++ b/src/Plugin/Block/ProxyBlock.php
@@ -11,12 +11,15 @@ use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Component\Plugin\Exception\ContextException;
 use Drupal\Core\Plugin\ContextAwarePluginInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\proxy_block\Service\TargetBlockCacheManager;
+use Drupal\proxy_block\Service\TargetBlockContextManager;
 use Drupal\proxy_block\Service\TargetBlockFactory;
 use Drupal\proxy_block\Service\TargetBlockFormProcessor;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -61,6 +64,24 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
   protected TargetBlockCacheManager $cacheManager;
 
   /**
+   * The context manager.
+   */
+  protected TargetBlockContextManager $contextManager;
+
+  /**
+   * Memoized target plugin definitions, keyed by target block id.
+   *
+   * Value is the plugin definition array, or FALSE when the lookup returned
+   * NULL / not-found (FALSE is distinguishable from "not yet looked up").
+   */
+  protected array $targetDefinitionCache = [];
+
+  /**
+   * The logger channel.
+   */
+  protected LoggerInterface $logger;
+
+  /**
    * Constructs a new AbTestProxyBlock.
    *
    * @param array $configuration
@@ -81,6 +102,10 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
    *   The form processor.
    * @param \Drupal\proxy_block\Service\TargetBlockCacheManager $cache_manager
    *   The cache manager.
+   * @param \Drupal\proxy_block\Service\TargetBlockContextManager $context_manager
+   *   The context manager.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger channel.
    */
   public function __construct(
     array $configuration,
@@ -92,6 +117,8 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
     TargetBlockFactory $target_block_factory,
     TargetBlockFormProcessor $form_processor,
     TargetBlockCacheManager $cache_manager,
+    TargetBlockContextManager $context_manager,
+    LoggerInterface $logger,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->blockManager = $block_manager;
@@ -100,6 +127,8 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
     $this->targetBlockFactory = $target_block_factory;
     $this->formProcessor = $form_processor;
     $this->cacheManager = $cache_manager;
+    $this->contextManager = $context_manager;
+    $this->logger = $logger;
   }
 
   /**
@@ -115,7 +144,9 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
       $container->get('request_stack'),
       $container->get(TargetBlockFactory::class),
       $container->get(TargetBlockFormProcessor::class),
-      $container->get(TargetBlockCacheManager::class)
+      $container->get(TargetBlockCacheManager::class),
+      $container->get(TargetBlockContextManager::class),
+      $container->get('logger.factory')->get('proxy_block'),
     );
   }
 
@@ -140,16 +171,34 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
    */
   public function getContextDefinitions() {
     $parent_definitions = parent::getContextDefinitions();
+    $definition = $this->getTargetPluginDefinition();
+    if ($definition === NULL) {
+      return $parent_definitions;
+    }
+    return ($definition['context_definitions'] ?? []) + $parent_definitions;
+  }
+
+  /**
+   * Returns the target block plugin definition, memoized.
+   *
+   * Used both by getContextDefinitions() and by build()'s admin-mode label
+   * lookup so a single blockManager call serves both.
+   *
+   * @return array|null
+   *   The plugin definition array, or NULL when no target is configured or
+   *   the target plugin can no longer be resolved.
+   */
+  protected function getTargetPluginDefinition(): ?array {
     $target_id = $this->configuration['target_block']['id'] ?? '';
-    if (empty($target_id)) {
-      return $parent_definitions;
+    if ($target_id === '') {
+      return NULL;
     }
-    $definition = $this->blockManager->getDefinition($target_id, FALSE);
-    if (!is_array($definition)) {
-      return $parent_definitions;
+    if (!array_key_exists($target_id, $this->targetDefinitionCache)) {
+      $definition = $this->blockManager->getDefinition($target_id, FALSE);
+      $this->targetDefinitionCache[$target_id] = is_array($definition) ? $definition : FALSE;
     }
-    $target_definitions = $definition['context_definitions'] ?? [];
-    return $target_definitions + $parent_definitions;
+    $definition = $this->targetDefinitionCache[$target_id];
+    return $definition === FALSE ? NULL : $definition;
   }
 
   /**
@@ -266,10 +315,54 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
     // target. The target's own context_mapping references identifiers that
     // only exist in section storage (e.g. 'layout_builder.entity'), which the
     // render-time repository-only fallback in TargetBlockContextManager
-    // cannot resolve.
+    // cannot resolve. Each setContext() is guarded so a single mismatched
+    // type cannot tear down the whole render.
     if ($target_block instanceof ContextAwarePluginInterface) {
-      foreach ($this->getContexts() as $name => $context) {
-        $target_block->setContext($name, $context);
+      $proxy_contexts = $this->getContexts();
+      foreach ($proxy_contexts as $name => $context) {
+        try {
+          $target_block->setContext($name, $context);
+        }
+        catch (ContextException $e) {
+          $this->logger->notice('Proxy block could not forward context "@name" to target @plugin: @message', [
+            '@name' => $name,
+            '@plugin' => $target_block->getPluginId(),
+            '@message' => $e->getMessage(),
+          ]);
+        }
+      }
+
+      // Last-ditch fallback: when the target still wants a content-entity
+      // context (entity / node) and Layout Builder provided its
+      // section-storage root entity under a different name (e.g.
+      // layout_builder.entity), bind it explicitly so plugins that look up
+      // by the conventional name still resolve.
+      $root_entity_context = $this->contextManager->resolveRootEntityContext($proxy_contexts);
+      if ($root_entity_context !== NULL) {
+        foreach (['entity', 'node'] as $fallback_name) {
+          if (!isset($target_block->getContextDefinitions()[$fallback_name])) {
+            continue;
+          }
+          try {
+            $existing = $target_block->getContext($fallback_name);
+            if ($existing->hasContextValue()) {
+              continue;
+            }
+          }
+          catch (ContextException) {
+            // No context bound under this name yet; fall through to set it.
+          }
+          try {
+            $target_block->setContext($fallback_name, $root_entity_context);
+          }
+          catch (ContextException $e) {
+            $this->logger->notice('Proxy block root-entity fallback could not bind "@name" on target @plugin: @message', [
+              '@name' => $fallback_name,
+              '@plugin' => $target_block->getPluginId(),
+              '@message' => $e->getMessage(),
+            ]);
+          }
+        }
       }
     }
 
@@ -285,7 +378,7 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
       $config = $this->getConfiguration();
       $target_plugin_id = $config['target_block']['id'] ?? '';
       if ($target_plugin_id) {
-        $block_definition = $this->blockManager->getDefinition($target_plugin_id);
+        $block_definition = $this->getTargetPluginDefinition() ?? [];
         $admin_label = $block_definition['admin_label'] ?? NULL;
         $block_label = $admin_label ?: $target_plugin_id ?: 'Unknown Block';
         // Extra safety: ensure the $block_label is always a non-empty string.

--- a/src/Plugin/Block/ProxyBlock.php
+++ b/src/Plugin/Block/ProxyBlock.php
@@ -131,6 +131,45 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
 
   /**
    * {@inheritdoc}
+   *
+   * Expose the target plugin's context definitions as our own. This lets
+   * Layout Builder treat the proxy as context-aware: it adds a context
+   * assignment element to the configure form and applies section-storage
+   * contexts to the proxy at render time, which build() then forwards to
+   * the target block.
+   */
+  public function getContextDefinitions() {
+    $parent_definitions = parent::getContextDefinitions();
+    $target_id = $this->configuration['target_block']['id'] ?? '';
+    if (empty($target_id)) {
+      return $parent_definitions;
+    }
+    $definition = $this->blockManager->getDefinition($target_id, FALSE);
+    if (!is_array($definition)) {
+      return $parent_definitions;
+    }
+    $target_definitions = $definition['context_definitions'] ?? [];
+    return $target_definitions + $parent_definitions;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Pair with getContextDefinitions(): the trait's singular form reads from
+   * the plugin definition directly, which doesn't know about target-mirrored
+   * contexts. Resolve through the merged map so getContexts() / cache
+   * metadata collection don't blow up with "context is not a valid context".
+   */
+  public function getContextDefinition($name) {
+    $definitions = $this->getContextDefinitions();
+    if (isset($definitions[$name])) {
+      return $definitions[$name];
+    }
+    return parent::getContextDefinition($name);
+  }
+
+  /**
+   * {@inheritdoc}
    */
   public function blockForm($form, FormStateInterface $form_state) {
     $form = parent::blockForm($form, $form_state);
@@ -177,6 +216,7 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
       $form['target_block']['config'] += $this->formProcessor->buildTargetBlockConfigurationForm(
         $selected_target_block['id'],
         $config,
+        $form_state,
       );
     }
 
@@ -202,7 +242,7 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
    */
   public function blockValidate($form, FormStateInterface $form_state) {
     parent::blockValidate($form, $form_state);
-    $this->formProcessor->validateTargetBlock($form_state, $this->getConfiguration());
+    $this->formProcessor->validateTargetBlock($form, $form_state, $this->getConfiguration());
   }
 
   /**
@@ -210,7 +250,7 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
    */
   public function blockSubmit($form, FormStateInterface $form_state) {
     parent::blockSubmit($form, $form_state);
-    $this->configuration = $this->formProcessor->submitTargetBlock($form_state);
+    $this->configuration = $this->formProcessor->submitTargetBlock($form, $form_state, $this->getConfiguration());
   }
 
   /**
@@ -220,6 +260,17 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
     $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
     if (!$target_block) {
       return [];
+    }
+
+    // Forward contexts that Layout Builder applied to this proxy onto the
+    // target. The target's own context_mapping references identifiers that
+    // only exist in section storage (e.g. 'layout_builder.entity'), which the
+    // render-time repository-only fallback in TargetBlockContextManager
+    // cannot resolve.
+    if ($target_block instanceof ContextAwarePluginInterface) {
+      foreach ($this->getContexts() as $name => $context) {
+        $target_block->setContext($name, $context);
+      }
     }
 
     $request = $this->requestStack->getCurrentRequest();

--- a/src/Plugin/Block/ProxyBlock.php
+++ b/src/Plugin/Block/ProxyBlock.php
@@ -7,21 +7,13 @@ namespace Drupal\proxy_block\Plugin\Block;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Block\BlockManagerInterface;
-use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Component\Plugin\Exception\ContextException;
 use Drupal\Core\Plugin\ContextAwarePluginInterface;
-use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\proxy_block\Service\TargetBlockCacheManager;
-use Drupal\proxy_block\Service\TargetBlockContextManager;
-use Drupal\proxy_block\Service\TargetBlockFactory;
+use Drupal\proxy_block\Service\ProxyBlockRenderer;
 use Drupal\proxy_block\Service\TargetBlockFormProcessor;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Provides a Proxy Block.
@@ -34,55 +26,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterface, ContextAwarePluginInterface {
 
   /**
-   * The block manager service.
-   */
-  protected BlockManagerInterface $blockManager;
-
-  /**
-   * The current user service.
-   */
-  protected AccountProxyInterface $currentUser;
-
-  /**
-   * The request stack.
-   */
-  protected RequestStack $requestStack;
-
-  /**
-   * The target block factory.
-   */
-  protected TargetBlockFactory $targetBlockFactory;
-
-  /**
-   * The form processor.
-   */
-  protected TargetBlockFormProcessor $formProcessor;
-
-  /**
-   * The cache manager.
-   */
-  protected TargetBlockCacheManager $cacheManager;
-
-  /**
-   * The context manager.
-   */
-  protected TargetBlockContextManager $contextManager;
-
-  /**
-   * Memoized target plugin definitions, keyed by target block id.
-   *
-   * Value is the plugin definition array, or FALSE when the lookup returned
-   * NULL / not-found (FALSE is distinguishable from "not yet looked up").
-   */
-  protected array $targetDefinitionCache = [];
-
-  /**
-   * The logger channel.
-   */
-  protected LoggerInterface $logger;
-
-  /**
-   * Constructs a new AbTestProxyBlock.
+   * Constructs a new ProxyBlock.
    *
    * @param array $configuration
    *   The plugin configuration.
@@ -90,45 +34,20 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
    *   The plugin ID.
    * @param mixed $plugin_definition
    *   The plugin definition.
-   * @param \Drupal\Core\Block\BlockManagerInterface $block_manager
-   *   The block manager service.
-   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
-   *   The current user service.
-   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
-   *   The request stack.
-   * @param \Drupal\proxy_block\Service\TargetBlockFactory $target_block_factory
-   *   The target block factory.
-   * @param \Drupal\proxy_block\Service\TargetBlockFormProcessor $form_processor
-   *   The form processor.
-   * @param \Drupal\proxy_block\Service\TargetBlockCacheManager $cache_manager
-   *   The cache manager.
-   * @param \Drupal\proxy_block\Service\TargetBlockContextManager $context_manager
-   *   The context manager.
-   * @param \Psr\Log\LoggerInterface $logger
-   *   The logger channel.
+   * @param \Drupal\proxy_block\Service\TargetBlockFormProcessor $formProcessor
+   *   The form processor (handles target selection, validation, submit).
+   * @param \Drupal\proxy_block\Service\ProxyBlockRenderer $renderer
+   *   The render-pipeline service (handles build, cache metadata, target
+   *   definition lookup).
    */
   public function __construct(
     array $configuration,
     string $plugin_id,
     mixed $plugin_definition,
-    BlockManagerInterface $block_manager,
-    AccountProxyInterface $current_user,
-    RequestStack $request_stack,
-    TargetBlockFactory $target_block_factory,
-    TargetBlockFormProcessor $form_processor,
-    TargetBlockCacheManager $cache_manager,
-    TargetBlockContextManager $context_manager,
-    LoggerInterface $logger,
+    protected TargetBlockFormProcessor $formProcessor,
+    protected ProxyBlockRenderer $renderer,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->blockManager = $block_manager;
-    $this->currentUser = $current_user;
-    $this->requestStack = $request_stack;
-    $this->targetBlockFactory = $target_block_factory;
-    $this->formProcessor = $form_processor;
-    $this->cacheManager = $cache_manager;
-    $this->contextManager = $context_manager;
-    $this->logger = $logger;
   }
 
   /**
@@ -139,14 +58,8 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('plugin.manager.block'),
-      $container->get('current_user'),
-      $container->get('request_stack'),
-      $container->get(TargetBlockFactory::class),
       $container->get(TargetBlockFormProcessor::class),
-      $container->get(TargetBlockCacheManager::class),
-      $container->get(TargetBlockContextManager::class),
-      $container->get('logger.factory')->get('proxy_block'),
+      $container->get(ProxyBlockRenderer::class),
     );
   }
 
@@ -171,34 +84,11 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
    */
   public function getContextDefinitions() {
     $parent_definitions = parent::getContextDefinitions();
-    $definition = $this->getTargetPluginDefinition();
+    $definition = $this->renderer->resolveTargetPluginDefinition($this->configuration);
     if ($definition === NULL) {
       return $parent_definitions;
     }
     return ($definition['context_definitions'] ?? []) + $parent_definitions;
-  }
-
-  /**
-   * Returns the target block plugin definition, memoized.
-   *
-   * Used both by getContextDefinitions() and by build()'s admin-mode label
-   * lookup so a single blockManager call serves both.
-   *
-   * @return array|null
-   *   The plugin definition array, or NULL when no target is configured or
-   *   the target plugin can no longer be resolved.
-   */
-  protected function getTargetPluginDefinition(): ?array {
-    $target_id = $this->configuration['target_block']['id'] ?? '';
-    if ($target_id === '') {
-      return NULL;
-    }
-    if (!array_key_exists($target_id, $this->targetDefinitionCache)) {
-      $definition = $this->blockManager->getDefinition($target_id, FALSE);
-      $this->targetDefinitionCache[$target_id] = is_array($definition) ? $definition : FALSE;
-    }
-    $definition = $this->targetDefinitionCache[$target_id];
-    return $definition === FALSE ? NULL : $definition;
   }
 
   /**
@@ -219,23 +109,29 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
 
   /**
    * {@inheritdoc}
+   *
+   * A/B variant swaps can change the target plugin id (and therefore the
+   * mirrored context definitions) between save and render. Drop mapping
+   * entries whose target-context name is no longer defined, otherwise
+   * ContextHandler::applyContextMapping() rejects the render with
+   * "Assigned contexts were not satisfied".
+   */
+  public function getContextMapping() {
+    $mapping = parent::getContextMapping();
+    if (empty($mapping)) {
+      return $mapping;
+    }
+    return array_intersect_key($mapping, $this->getContextDefinitions());
+  }
+
+  /**
+   * {@inheritdoc}
    */
   public function blockForm($form, FormStateInterface $form_state) {
     $form = parent::blockForm($form, $form_state);
     $config = $this->getConfiguration();
 
-    $block_definitions = $this->blockManager->getDefinitions();
-    $block_options = array_map(
-      static fn ($definition) => $definition['admin_label'] ?? $definition['id'],
-      array_filter(
-        $block_definitions,
-        fn ($definition, $plugin_id) => $plugin_id !== $this->getPluginId(),
-        ARRAY_FILTER_USE_BOTH
-      )
-    );
-    $block_options = array_unique($block_options);
-    asort($block_options);
-
+    $block_options = $this->formProcessor->getAvailableBlockOptions($this->getPluginId());
     $wrapper_id = 'target-block-config-wrapper';
 
     $form['target_block'] = [
@@ -306,137 +202,36 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
    * {@inheritdoc}
    */
   public function build(): array {
-    $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
-    if (!$target_block) {
-      return [];
-    }
-
-    // Forward contexts that Layout Builder applied to this proxy onto the
-    // target. The target's own context_mapping references identifiers that
-    // only exist in section storage (e.g. 'layout_builder.entity'), which the
-    // render-time repository-only fallback in TargetBlockContextManager
-    // cannot resolve. Each setContext() is guarded so a single mismatched
-    // type cannot tear down the whole render.
-    if ($target_block instanceof ContextAwarePluginInterface) {
-      $proxy_contexts = $this->getContexts();
-      foreach ($proxy_contexts as $name => $context) {
-        try {
-          $target_block->setContext($name, $context);
-        }
-        catch (ContextException $e) {
-          $this->logger->notice('Proxy block could not forward context "@name" to target @plugin: @message', [
-            '@name' => $name,
-            '@plugin' => $target_block->getPluginId(),
-            '@message' => $e->getMessage(),
-          ]);
-        }
-      }
-
-      // Last-ditch fallback: when the target still wants a content-entity
-      // context (entity / node) and Layout Builder provided its
-      // section-storage root entity under a different name (e.g.
-      // layout_builder.entity), bind it explicitly so plugins that look up
-      // by the conventional name still resolve.
-      $root_entity_context = $this->contextManager->resolveRootEntityContext($proxy_contexts);
-      if ($root_entity_context !== NULL) {
-        foreach (['entity', 'node'] as $fallback_name) {
-          if (!isset($target_block->getContextDefinitions()[$fallback_name])) {
-            continue;
-          }
-          try {
-            $existing = $target_block->getContext($fallback_name);
-            if ($existing->hasContextValue()) {
-              continue;
-            }
-          }
-          catch (ContextException) {
-            // No context bound under this name yet; fall through to set it.
-          }
-          try {
-            $target_block->setContext($fallback_name, $root_entity_context);
-          }
-          catch (ContextException $e) {
-            $this->logger->notice('Proxy block root-entity fallback could not bind "@name" on target @plugin: @message', [
-              '@name' => $fallback_name,
-              '@plugin' => $target_block->getPluginId(),
-              '@message' => $e->getMessage(),
-            ]);
-          }
-        }
-      }
-    }
-
-    $request = $this->requestStack->getCurrentRequest();
-    $is_layout_builder_admin = $request && (
-      (str_contains($request->getPathInfo(), '/admin/structure/types/') && str_contains($request->getPathInfo(), '/display/') && str_contains($request->getPathInfo(), '/layout'))
-      || str_contains($request->getPathInfo(), '/layout_builder/update/block/')
-      || str_contains($request->getPathInfo(), '/layout_builder/add/block/')
-      || ($request->query->get('destination') && str_contains($request->query->get('destination'), '/layout'))
+    return $this->renderer->render(
+      $this->getConfiguration(),
+      $this->getContexts(),
+      parent::getCacheContexts(),
+      parent::getCacheTags(),
+      parent::getCacheMaxAge(),
+      $this->getPluginId(),
+      $this,
     );
-
-    if ($is_layout_builder_admin) {
-      $config = $this->getConfiguration();
-      $target_plugin_id = $config['target_block']['id'] ?? '';
-      if ($target_plugin_id) {
-        $block_definition = $this->getTargetPluginDefinition() ?? [];
-        $admin_label = $block_definition['admin_label'] ?? NULL;
-        $block_label = $admin_label ?: $target_plugin_id ?: 'Unknown Block';
-        // Extra safety: ensure the $block_label is always a non-empty string.
-        $block_label = (string) $block_label;
-        return [
-          '#markup' => '<div class="layout-builder-block"><strong>Proxy Block:</strong> ' . $this->t('Configured to render "@block"', ['@block' => $block_label]) . '</div>',
-          '#cache' => [
-            'contexts' => $this->getCacheContexts(),
-            'tags' => $this->getCacheTags(),
-            'max-age' => $this->getCacheMaxAge(),
-          ],
-        ];
-      }
-    }
-
-    $access_result = $target_block->access($this->currentUser, TRUE);
-    if (!$access_result->isAllowed()) {
-      $build = [
-        '#markup' => '',
-        '#cache' => [
-          'contexts' => $this->getCacheContexts(),
-          'tags' => $this->getCacheTags(),
-          'max-age' => $this->getCacheMaxAge(),
-        ],
-      ];
-      CacheableMetadata::createFromObject($access_result)->applyTo($build);
-      return $build;
-    }
-
-    $build = $target_block->build();
-    $this->cacheManager->bubbleTargetBlockCacheMetadata($build, $target_block, $this);
-    return $build;
   }
 
   /**
    * {@inheritdoc}
    */
   public function getCacheContexts(): array {
-    $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
-    return $this->cacheManager->getCacheContexts($target_block, parent::getCacheContexts());
+    return $this->renderer->collectCacheContexts($this->getConfiguration(), parent::getCacheContexts());
   }
 
   /**
    * {@inheritdoc}
    */
   public function getCacheTags(): array {
-    $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
-    $cache_tags = $this->cacheManager->getCacheTags($target_block, parent::getCacheTags());
-    $cache_tags[] = 'proxy_block_proxy:' . $this->getPluginId();
-    return $cache_tags;
+    return $this->renderer->collectCacheTags($this->getConfiguration(), parent::getCacheTags(), $this->getPluginId());
   }
 
   /**
    * {@inheritdoc}
    */
   public function getCacheMaxAge(): int {
-    $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
-    return $this->cacheManager->getCacheMaxAge($target_block, parent::getCacheMaxAge());
+    return $this->renderer->collectCacheMaxAge($this->getConfiguration(), parent::getCacheMaxAge());
   }
 
 }

--- a/src/Service/ProxyBlockRenderer.php
+++ b/src/Service/ProxyBlockRenderer.php
@@ -1,0 +1,347 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\proxy_block\Service;
+
+use Drupal\Component\Plugin\Exception\ContextException;
+use Drupal\Core\Block\BlockManagerInterface;
+use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Cache\CacheableDependencyInterface;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Plugin\ContextAwarePluginInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Renders proxy blocks and answers their cache-metadata queries.
+ *
+ * Extracted out of \Drupal\proxy_block\Plugin\Block\ProxyBlock so the plugin
+ * itself can stay thin. All render-time and cache-metadata orchestration
+ * lives here; ProxyBlock delegates and threads its parent's contributions
+ * (parent cache contexts/tags/max-age) through where needed.
+ */
+class ProxyBlockRenderer {
+
+  use StringTranslationTrait;
+
+  /**
+   * Memoized target plugin definitions, keyed by target block id.
+   *
+   * FALSE is stored when the lookup returned NULL, to distinguish "not
+   * found" from "not yet looked up". Keys are target plugin ids.
+   */
+  protected array $targetDefinitionCache = [];
+
+  /**
+   * Constructs a new ProxyBlockRenderer.
+   *
+   * @param \Drupal\proxy_block\Service\TargetBlockFactory $targetBlockFactory
+   *   The target block factory.
+   * @param \Drupal\proxy_block\Service\TargetBlockContextManager $contextManager
+   *   The target block context manager.
+   * @param \Drupal\proxy_block\Service\TargetBlockCacheManager $cacheManager
+   *   The target block cache manager.
+   * @param \Drupal\Core\Block\BlockManagerInterface $blockManager
+   *   The block plugin manager.
+   * @param \Drupal\Core\Session\AccountProxyInterface $currentUser
+   *   The current user.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
+   *   The request stack.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger channel.
+   */
+  public function __construct(
+    protected TargetBlockFactory $targetBlockFactory,
+    protected TargetBlockContextManager $contextManager,
+    protected TargetBlockCacheManager $cacheManager,
+    protected BlockManagerInterface $blockManager,
+    protected AccountProxyInterface $currentUser,
+    protected RequestStack $requestStack,
+    #[Autowire(service: 'logger.channel.proxy_block')]
+    protected LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Resolves and memoizes the target block's plugin definition.
+   *
+   * @param array $configuration
+   *   The proxy block configuration.
+   *
+   * @return array|null
+   *   The plugin definition array, or NULL when no target is configured or
+   *   the target plugin can no longer be resolved.
+   */
+  public function resolveTargetPluginDefinition(array $configuration): ?array {
+    $target_id = $configuration['target_block']['id'] ?? '';
+    if ($target_id === '') {
+      return NULL;
+    }
+    if (!array_key_exists($target_id, $this->targetDefinitionCache)) {
+      $definition = $this->blockManager->getDefinition($target_id, FALSE);
+      $this->targetDefinitionCache[$target_id] = is_array($definition) ? $definition : FALSE;
+    }
+    $definition = $this->targetDefinitionCache[$target_id];
+    return $definition === FALSE ? NULL : $definition;
+  }
+
+  /**
+   * Renders the proxy block.
+   *
+   * Takes plain values rather than the ProxyBlock plugin instance so the
+   * renderer is decoupled from the (final) plugin class and easy to unit
+   * test in isolation. The plugin instance is passed through only because
+   * TargetBlockCacheManager::bubbleTargetBlockCacheMetadata() needs it for
+   * the access-result merge step.
+   *
+   * @param array $configuration
+   *   The proxy block configuration.
+   * @param \Drupal\Core\Plugin\Context\ContextInterface[] $proxyContexts
+   *   The contexts already applied to the proxy.
+   * @param array $parentCacheContexts
+   *   Parent BlockBase cache contexts (for the embedded cache metadata in
+   *   admin-preview / access-denied branches).
+   * @param array $parentCacheTags
+   *   Parent BlockBase cache tags.
+   * @param int $parentCacheMaxAge
+   *   Parent BlockBase cache max-age.
+   * @param string $proxyPluginId
+   *   The proxy plugin id, for the proxy-specific cache tag.
+   * @param \Drupal\Core\Cache\CacheableDependencyInterface $proxyForBubbling
+   *   The proxy plugin instance, forwarded to
+   *   TargetBlockCacheManager::bubbleTargetBlockCacheMetadata() for its
+   *   cache-dependency merge.
+   *
+   * @return array
+   *   The render array.
+   */
+  public function render(
+    array $configuration,
+    array $proxyContexts,
+    array $parentCacheContexts,
+    array $parentCacheTags,
+    int $parentCacheMaxAge,
+    string $proxyPluginId,
+    CacheableDependencyInterface $proxyForBubbling,
+  ): array {
+    $target_block = $this->targetBlockFactory->getTargetBlock($configuration);
+    if (!$target_block) {
+      return [];
+    }
+
+    if ($target_block instanceof ContextAwarePluginInterface) {
+      $this->forwardContexts($target_block, $proxyContexts);
+    }
+
+    if ($this->isLayoutBuilderAdminRoute()) {
+      $admin_view = $this->buildLayoutBuilderAdminPreview(
+        $configuration,
+        $parentCacheContexts,
+        $parentCacheTags,
+        $parentCacheMaxAge,
+        $proxyPluginId,
+      );
+      if ($admin_view !== NULL) {
+        return $admin_view;
+      }
+    }
+
+    $access_result = $target_block->access($this->currentUser, TRUE);
+    if (!$access_result->isAllowed()) {
+      $build = [
+        '#markup' => '',
+        '#cache' => [
+          'contexts' => $this->collectCacheContexts($configuration, $parentCacheContexts),
+          'tags' => $this->collectCacheTags($configuration, $parentCacheTags, $proxyPluginId),
+          'max-age' => $this->collectCacheMaxAge($configuration, $parentCacheMaxAge),
+        ],
+      ];
+      CacheableMetadata::createFromObject($access_result)->applyTo($build);
+      return $build;
+    }
+
+    $build = $target_block->build();
+    $this->cacheManager->bubbleTargetBlockCacheMetadata($build, $target_block, $proxyForBubbling);
+    return $build;
+  }
+
+  /**
+   * Computes cache contexts for the proxy.
+   *
+   * @param array $configuration
+   *   The proxy configuration.
+   * @param array $parentCacheContexts
+   *   The contributions from parent::getCacheContexts() on the plugin.
+   *
+   * @return array
+   *   The merged cache contexts.
+   */
+  public function collectCacheContexts(array $configuration, array $parentCacheContexts): array {
+    $target_block = $this->targetBlockFactory->getTargetBlock($configuration);
+    return $this->cacheManager->getCacheContexts($target_block, $parentCacheContexts);
+  }
+
+  /**
+   * Computes cache tags for the proxy.
+   *
+   * @param array $configuration
+   *   The proxy configuration.
+   * @param array $parentCacheTags
+   *   The contributions from parent::getCacheTags() on the plugin.
+   * @param string $proxyPluginId
+   *   The proxy plugin id, used to compose a proxy-specific tag.
+   *
+   * @return array
+   *   The merged cache tags.
+   */
+  public function collectCacheTags(array $configuration, array $parentCacheTags, string $proxyPluginId): array {
+    $target_block = $this->targetBlockFactory->getTargetBlock($configuration);
+    $cache_tags = $this->cacheManager->getCacheTags($target_block, $parentCacheTags);
+    $cache_tags[] = 'proxy_block_proxy:' . $proxyPluginId;
+    return $cache_tags;
+  }
+
+  /**
+   * Computes the cache max-age for the proxy.
+   *
+   * @param array $configuration
+   *   The proxy configuration.
+   * @param int $parentMaxAge
+   *   The contribution from parent::getCacheMaxAge() on the plugin.
+   *
+   * @return int
+   *   The merged cache max-age.
+   */
+  public function collectCacheMaxAge(array $configuration, int $parentMaxAge): int {
+    $target_block = $this->targetBlockFactory->getTargetBlock($configuration);
+    return $this->cacheManager->getCacheMaxAge($target_block, $parentMaxAge);
+  }
+
+  /**
+   * Forwards proxy-level contexts onto the target, with fallbacks.
+   *
+   * Each setContext() is guarded so a single mismatched type cannot tear
+   * down the whole render. When the target still wants the conventional
+   * 'entity' / 'node' name but Layout Builder only supplied
+   * 'layout_builder.entity', the root-entity fallback binds it.
+   *
+   * @param \Drupal\Core\Plugin\ContextAwarePluginInterface $target_block
+   *   The target block.
+   * @param \Drupal\Core\Plugin\Context\ContextInterface[] $proxy_contexts
+   *   The contexts already applied to the proxy by Layout Builder / core.
+   */
+  protected function forwardContexts(ContextAwarePluginInterface $target_block, array $proxy_contexts): void {
+    foreach ($proxy_contexts as $name => $context) {
+      try {
+        $target_block->setContext($name, $context);
+      }
+      catch (ContextException $e) {
+        $this->logger->notice('Proxy block could not forward context "@name" to target @plugin: @message', [
+          '@name' => $name,
+          '@plugin' => $target_block->getPluginId(),
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    $root_entity_context = $this->contextManager->resolveRootEntityContext($proxy_contexts);
+    if ($root_entity_context === NULL) {
+      return;
+    }
+    foreach (['entity', 'node'] as $fallback_name) {
+      if (!isset($target_block->getContextDefinitions()[$fallback_name])) {
+        continue;
+      }
+      try {
+        $existing = $target_block->getContext($fallback_name);
+        if ($existing->hasContextValue()) {
+          continue;
+        }
+      }
+      catch (ContextException) {
+        // No context bound under this name yet; fall through to set it.
+      }
+      try {
+        $target_block->setContext($fallback_name, $root_entity_context);
+      }
+      catch (ContextException $e) {
+        $this->logger->notice('Proxy block root-entity fallback could not bind "@name" on target @plugin: @message', [
+          '@name' => $fallback_name,
+          '@plugin' => $target_block->getPluginId(),
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+  }
+
+  /**
+   * Detects whether the current request is a Layout Builder admin route.
+   */
+  protected function isLayoutBuilderAdminRoute(): bool {
+    $request = $this->requestStack->getCurrentRequest();
+    if (!$request) {
+      return FALSE;
+    }
+    $path = $request->getPathInfo();
+    if (str_contains($path, '/admin/structure/types/')
+      && str_contains($path, '/display/')
+      && str_contains($path, '/layout')
+    ) {
+      return TRUE;
+    }
+    if (str_contains($path, '/layout_builder/update/block/')
+      || str_contains($path, '/layout_builder/add/block/')
+    ) {
+      return TRUE;
+    }
+    $destination = $request->query->get('destination');
+    return is_string($destination) && str_contains($destination, '/layout');
+  }
+
+  /**
+   * Builds the Layout Builder admin "placeholder" preview render array.
+   *
+   * @return array|null
+   *   A render array, or NULL when there's no target plugin id to preview.
+   */
+  protected function buildLayoutBuilderAdminPreview(
+    array $configuration,
+    array $parentCacheContexts,
+    array $parentCacheTags,
+    int $parentCacheMaxAge,
+    string $proxyPluginId,
+  ): ?array {
+    $target_plugin_id = $configuration['target_block']['id'] ?? '';
+    if (!$target_plugin_id) {
+      return NULL;
+    }
+    $block_definition = $this->resolveTargetPluginDefinition($configuration) ?? [];
+    $admin_label = $block_definition['admin_label'] ?? NULL;
+    $block_label = (string) ($admin_label ?: $target_plugin_id ?: 'Unknown Block');
+    return [
+      '#markup' => '<div class="layout-builder-block"><strong>Proxy Block:</strong> ' . $this->t('Configured to render "@block"', ['@block' => $block_label]) . '</div>',
+      '#cache' => [
+        'contexts' => $this->collectCacheContexts($configuration, $parentCacheContexts),
+        'tags' => $this->collectCacheTags($configuration, $parentCacheTags, $proxyPluginId),
+        'max-age' => $this->collectCacheMaxAge($configuration, $parentCacheMaxAge),
+      ],
+    ];
+  }
+
+  /**
+   * Returns the wrapped block instance for a configuration, if creatable.
+   *
+   * Convenience pass-through so callers needing the target instance don't
+   * have to depend on the factory directly.
+   *
+   * @param array $configuration
+   *   The proxy configuration.
+   */
+  public function getTargetBlock(array $configuration): ?BlockPluginInterface {
+    return $this->targetBlockFactory->getTargetBlock($configuration);
+  }
+
+}

--- a/src/Service/TargetBlockContextManager.php
+++ b/src/Service/TargetBlockContextManager.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\proxy_block\Service;
 
+use Drupal\Core\Entity\Plugin\DataType\EntityAdapter;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\Context\Context;
 use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\Core\Plugin\Context\ContextHandlerInterface;
+use Drupal\Core\Plugin\Context\ContextInterface;
 use Drupal\Core\Plugin\Context\ContextRepositoryInterface;
+use Drupal\Component\Plugin\Exception\ContextException;
 use Drupal\Core\Plugin\ContextAwarePluginInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Manages context for the target block.
@@ -26,10 +31,14 @@ class TargetBlockContextManager {
    *   The context repository.
    * @param \Drupal\Core\Plugin\Context\ContextHandlerInterface $contextHandler
    *   The context handler.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger channel.
    */
   public function __construct(
     protected ContextRepositoryInterface $contextRepository,
     protected ContextHandlerInterface $contextHandler,
+    #[Autowire(service: 'logger.channel.proxy_block')]
+    protected LoggerInterface $logger,
   ) {}
 
   /**
@@ -83,59 +92,80 @@ class TargetBlockContextManager {
    *   The target block plugin.
    */
   public function applyContextsToTargetBlock(ContextAwarePluginInterface $target_block): void {
+    $gathered_contexts = $this->getGatheredContexts();
+    $context_mapping = $target_block->getContextMapping();
+
+    $target_context_definitions = $target_block->getContextDefinitions();
+    $missing_required_contexts = array_keys(array_filter(
+      $target_context_definitions,
+      static fn ($definition, $name) => $definition->isRequired() && !isset($context_mapping[$name]),
+      ARRAY_FILTER_USE_BOTH,
+    ));
+
+    if (empty($context_mapping) || !empty($missing_required_contexts)) {
+      $automatic_mapping = $this->generateAutomaticContextMapping($target_block, $gathered_contexts);
+      if (!empty($automatic_mapping)) {
+        $context_mapping = $context_mapping + $automatic_mapping;
+        $target_block->setContextMapping($context_mapping);
+      }
+    }
+
+    if (empty($gathered_contexts) || empty($context_mapping)) {
+      return;
+    }
+
+    $resolved_mapping = [];
+    foreach ($context_mapping as $target_context => $source_context_id) {
+      $clean_context_id = ltrim($source_context_id, '@');
+      if (isset($gathered_contexts[$clean_context_id])) {
+        $resolved_mapping[$target_context] = $clean_context_id;
+      }
+      elseif (isset($gathered_contexts[$source_context_id])) {
+        $resolved_mapping[$target_context] = $source_context_id;
+      }
+    }
+
+    if (empty($resolved_mapping)) {
+      return;
+    }
+
     try {
-      $gathered_contexts = $this->getGatheredContexts();
-      $context_mapping = $target_block->getContextMapping();
+      $this->contextHandler->applyContextMapping($target_block, $gathered_contexts, $resolved_mapping);
+    }
+    catch (ContextException $e) {
+      $this->logger->notice('Proxy block could not apply context mapping for target @plugin: @message', [
+        '@plugin' => $target_block->getPluginId(),
+        '@message' => $e->getMessage(),
+      ]);
+    }
+  }
 
-      $target_context_definitions = $target_block->getContextDefinitions();
-      $missing_required_contexts = [];
-
-      foreach ($target_context_definitions as $context_name => $context_definition) {
-        if ($context_definition->isRequired() && !isset($context_mapping[$context_name])) {
-          $missing_required_contexts[] = $context_name;
-        }
+  /**
+   * Probes a context bag for the Layout Builder section-storage root entity.
+   *
+   * Mirrors the lookup ab_blocks' AjaxBlockRender uses: a small whitelist of
+   * conventional context names, in priority order. Returns the first context
+   * whose value is a content entity.
+   *
+   * @param \Drupal\Core\Plugin\Context\ContextInterface[] $contexts
+   *   The context bag to probe (typically the proxy's own
+   *   getContexts() output, or the gathered contexts).
+   *
+   * @return \Drupal\Core\Plugin\Context\ContextInterface|null
+   *   The first matching context, or NULL when none is found.
+   */
+  public function resolveRootEntityContext(array $contexts): ?ContextInterface {
+    foreach (['layout_builder.entity', 'entity', 'node'] as $key) {
+      if (!isset($contexts[$key])) {
+        continue;
       }
-
-      if (empty($context_mapping) || !empty($missing_required_contexts)) {
-
-        $automatic_mapping = $this->generateAutomaticContextMapping($target_block, $gathered_contexts);
-        if (!empty($automatic_mapping)) {
-          $merged_mapping = $context_mapping + $automatic_mapping;
-          $target_block->setContextMapping($merged_mapping);
-          $context_mapping = $merged_mapping;
-
-        }
-      }
-
-      if (!empty($gathered_contexts) && !empty($context_mapping)) {
-        $resolved_mapping = [];
-        foreach ($context_mapping as $target_context => $source_context_id) {
-          $clean_context_id = ltrim($source_context_id, '@');
-
-          if (isset($gathered_contexts[$clean_context_id])) {
-            $resolved_mapping[$target_context] = $clean_context_id;
-          }
-          elseif (isset($gathered_contexts[$source_context_id])) {
-            $resolved_mapping[$target_context] = $source_context_id;
-          }
-          else {
-          }
-        }
-
-        if (!empty($resolved_mapping)) {
-
-          try {
-            $this->contextHandler->applyContextMapping($target_block, $gathered_contexts, $resolved_mapping);
-          }
-          catch (\Exception $e) {
-            // The context application failed, continue without contexts.
-          }
-        }
+      $context = $contexts[$key];
+      $data = $context->getContextData();
+      if ($data instanceof EntityAdapter && $data->getValue() !== NULL) {
+        return $context;
       }
     }
-    catch (\Exception $e) {
-      // Failed to apply contexts to the target block, continue without them.
-    }
+    return NULL;
   }
 
   /**

--- a/src/Service/TargetBlockContextManager.php
+++ b/src/Service/TargetBlockContextManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\proxy_block\Service;
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\Context\Context;
 use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\Core\Plugin\Context\ContextHandlerInterface;
@@ -34,10 +35,24 @@ class TargetBlockContextManager {
   /**
    * Gets all gathered contexts like Layout Builder does.
    *
+   * @param \Drupal\Core\Form\FormStateInterface|null $form_state
+   *   The form state from the calling configure form, when available. Layout
+   *   Builder's configure form populates a 'gathered_contexts' temporary value
+   *   that merges section storage contexts with repository contexts; the
+   *   directly-placed block path consumes that same value, so honoring it here
+   *   keeps proxied placements in parity with native placements.
+   *
    * @return \Drupal\Core\Plugin\Context\ContextInterface[]
    *   Array of available contexts.
    */
-  public function getGatheredContexts(): array {
+  public function getGatheredContexts(?FormStateInterface $form_state = NULL): array {
+    if ($form_state !== NULL) {
+      $contexts = $form_state->getTemporaryValue('gathered_contexts');
+      if (is_array($contexts) && !empty($contexts)) {
+        return $contexts;
+      }
+    }
+
     $available_context_ids = $this->contextRepository->getAvailableContexts();
     $contexts = $this->contextRepository->getRuntimeContexts(array_keys($available_context_ids));
 

--- a/src/Service/TargetBlockFormProcessor.php
+++ b/src/Service/TargetBlockFormProcessor.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\proxy_block\Service;
 
-use Drupal\Core\Block\BlockPluginInterface;
-use Drupal\Core\Form\FormState;
 use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Block\BlockManagerInterface;
+use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Form\FormState;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Form\SubformState;
 use Drupal\Core\Plugin\ContextAwarePluginAssignmentTrait;
 use Drupal\Core\Plugin\ContextAwarePluginInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
@@ -43,11 +44,15 @@ class TargetBlockFormProcessor {
    *   The selected block plugin ID.
    * @param array $configuration
    *   The proxy block configuration.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state of the calling form. Forwarded to the context manager so
+   *   Layout Builder's section-storage contexts (exposed via the
+   *   'gathered_contexts' temporary value) drive the context-mapping element.
    *
    * @return array
    *   The configuration form elements.
    */
-  public function buildTargetBlockConfigurationForm(string $plugin_id, array $configuration): array {
+  public function buildTargetBlockConfigurationForm(string $plugin_id, array $configuration, FormStateInterface $form_state): array {
     $block_config = $configuration['target_block']['config'] ?? [];
     $form_elements = [];
 
@@ -88,8 +93,19 @@ class TargetBlockFormProcessor {
       }
 
       if ($target_block instanceof ContextAwarePluginInterface) {
-        $gathered_contexts = $this->contextManager->getGatheredContexts();
-        $form_elements['context_mapping'] = $this->addContextAssignmentElement($target_block, $gathered_contexts);
+        // When the proxy is configured inside Layout Builder, LB already
+        // renders a context_mapping element at the form root against the
+        // proxy block's own (target-mirrored) context definitions. Adding
+        // a second one here would duplicate the UI and split the saved
+        // mapping across two places. Detect LB by the presence of its
+        // 'gathered_contexts' temporary value and skip the inner element
+        // in that case.
+        $lb_gathered = $form_state->getTemporaryValue('gathered_contexts');
+        $inside_layout_builder = is_array($lb_gathered) && !empty($lb_gathered);
+        if (!$inside_layout_builder) {
+          $gathered_contexts = $this->contextManager->getGatheredContexts($form_state);
+          $form_elements['context_mapping'] = $this->addContextAssignmentElement($target_block, $gathered_contexts);
+        }
       }
 
       return $form_elements;
@@ -113,73 +129,112 @@ class TargetBlockFormProcessor {
   /**
    * Validates the target block configuration.
    *
+   * @param array $form
+   *   The parent form structure, used to scope a SubformState to the nested
+   *   block-config sub-form so target plugins read the correct values.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The form state.
    * @param array $configuration
    *   The proxy block configuration.
    */
-  public function validateTargetBlock(FormStateInterface $form_state, array $configuration): void {
+  public function validateTargetBlock(array $form, FormStateInterface $form_state, array $configuration): void {
     $target_block_plugin = $form_state->getValue(['target_block', 'id']);
-    if (!empty($target_block_plugin)) {
-      $block_config = $form_state->getValue(['target_block', 'config']) ?? $configuration['target_block']['config'] ?? [];
+    if (empty($target_block_plugin)) {
+      return;
+    }
 
-      try {
-        $this->blockManager->createInstance($target_block_plugin, $block_config);
+    // The AJAX-built target form nests block-config values under
+    // target_block.config.block_config; read from that exact path so the
+    // values match what the sub-form actually rendered.
+    $block_config = $form_state->getValue(['target_block', 'config', 'block_config'])
+      ?? $configuration['target_block']['config']
+      ?? [];
+
+    try {
+      $target_block = $this->blockManager->createInstance($target_block_plugin, $block_config);
+
+      if ($target_block instanceof PluginFormInterface) {
+        $sub_form = $form['target_block']['config']['block_config'] ?? [];
+        if (!empty($sub_form)) {
+          $subform_state = SubformState::createForSubform($sub_form, $form, $form_state);
+          $target_block->validateConfigurationForm($sub_form, $subform_state);
+        }
       }
-      catch (PluginException $e) {
-        $form_state->setErrorByName('target_block][id', $this->t('Invalid target block plugin: @message', [
-          '@message' => $e->getMessage(),
-        ]));
-      }
+    }
+    catch (PluginException $e) {
+      $form_state->setErrorByName('target_block][id', $this->t('Invalid target block plugin: @message', [
+        '@message' => $e->getMessage(),
+      ]));
     }
   }
 
   /**
    * Submits the target block configuration.
    *
+   * @param array $form
+   *   The parent form structure, used to scope a SubformState to the nested
+   *   block-config sub-form so the target plugin's own submit lifecycle sees
+   *   the correct values.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The form state.
+   * @param array $configuration
+   *   The current proxy block configuration. Any keys outside of
+   *   `target_block` are preserved in the returned array.
    *
    * @return array
-   *   The updated proxy block configuration.
+   *   The full proxy block configuration with the submitted target block
+   *   values merged in (submitted values win over the existing ones).
    */
-  public function submitTargetBlock(FormStateInterface $form_state): array {
+  public function submitTargetBlock(array $form, FormStateInterface $form_state, array $configuration): array {
     $target_plugin_id = $form_state->getValue(['target_block', 'id']);
-    $configuration = [];
-    $configuration['target_block']['id'] = $target_plugin_id;
+    $submitted = [];
+    $submitted['target_block']['id'] = $target_plugin_id;
 
-    if (!empty($target_plugin_id)) {
-      $block_config = $form_state->getValue(['target_block', 'config']) ?? [];
+    if (empty($target_plugin_id)) {
+      $submitted['target_block']['config'] = [];
+      return $submitted + $configuration;
+    }
 
-      try {
-        $target_block = $this->blockManager->createInstance($target_plugin_id, $block_config);
+    // Read the unwrapped block-config values (the AJAX-built sub-form lives
+    // at target_block.config.block_config). Reading from target_block.config
+    // would return the wrapper array and pollute the plugin's configuration
+    // with leftover 'block_config' / 'context_mapping' keys.
+    $block_config = $form_state->getValue(['target_block', 'config', 'block_config']) ?? [];
 
-        if ($target_block instanceof PluginFormInterface && $target_block instanceof BlockPluginInterface) {
-          $target_block->setConfiguration($block_config + $target_block->getConfiguration());
-        }
+    try {
+      $target_block = $this->blockManager->createInstance($target_plugin_id, $block_config);
 
-        if ($target_block instanceof ContextAwarePluginInterface) {
-          $context_mapping = $form_state->getValue(['target_block', 'config', 'context_mapping']) ?? [];
-          $target_block->setContextMapping($context_mapping);
-        }
-
-        // Get the final configuration after all modifications.
-        if ($target_block instanceof PluginFormInterface && $target_block instanceof BlockPluginInterface) {
-          $configuration['target_block']['config'] = $target_block->getConfiguration();
+      // Route block-config values through the target plugin's own submit
+      // lifecycle so plugins reading $form_state->getValues() see the
+      // sub-form scope rather than the parent scope.
+      if ($target_block instanceof PluginFormInterface && $target_block instanceof BlockPluginInterface) {
+        $sub_form = $form['target_block']['config']['block_config'] ?? [];
+        if (!empty($sub_form)) {
+          $subform_state = SubformState::createForSubform($sub_form, $form, $form_state);
+          $target_block->submitConfigurationForm($sub_form, $subform_state);
         }
         else {
-          $configuration['target_block']['config'] = $block_config;
+          // Plugin built no config form; fall back to a direct merge so any
+          // values present still reach the configuration array.
+          $target_block->setConfiguration($block_config + $target_block->getConfiguration());
         }
       }
-      catch (PluginException $e) {
-        $configuration['target_block']['config'] = [];
+
+      if ($target_block instanceof ContextAwarePluginInterface) {
+        $context_mapping = $form_state->getValue(['target_block', 'config', 'context_mapping']) ?? [];
+        $target_block->setContextMapping($context_mapping);
       }
+
+      // Persist the unwrapped target plugin configuration.
+      $submitted['target_block']['config'] = $target_block instanceof BlockPluginInterface
+        ? $target_block->getConfiguration()
+        : $block_config;
     }
-    else {
-      $configuration['target_block']['config'] = [];
+    catch (PluginException $e) {
+      $submitted['target_block']['config'] = [];
     }
 
-    return $configuration;
+    return $submitted + $configuration;
   }
 
   /**

--- a/src/Service/TargetBlockFormProcessor.php
+++ b/src/Service/TargetBlockFormProcessor.php
@@ -244,6 +244,30 @@ class TargetBlockFormProcessor {
   }
 
   /**
+   * Builds the list of block plugins available as proxy targets.
+   *
+   * @param string $excluded_plugin_id
+   *   The plugin id of the proxy itself, excluded to prevent self-reference.
+   *
+   * @return array
+   *   Map of plugin id => admin label, sorted alphabetically by label.
+   */
+  public function getAvailableBlockOptions(string $excluded_plugin_id): array {
+    $definitions = $this->blockManager->getDefinitions();
+    $options = array_map(
+      static fn ($definition) => $definition['admin_label'] ?? $definition['id'],
+      array_filter(
+        $definitions,
+        static fn ($definition, $plugin_id) => $plugin_id !== $excluded_plugin_id,
+        ARRAY_FILTER_USE_BOTH,
+      ),
+    );
+    $options = array_unique($options);
+    asort($options);
+    return $options;
+  }
+
+  /**
    * Gets the selected target from the form state.
    *
    * @param \Drupal\Core\Form\FormStateInterface $form_state

--- a/src/Service/TargetBlockFormProcessor.php
+++ b/src/Service/TargetBlockFormProcessor.php
@@ -221,8 +221,14 @@ class TargetBlockFormProcessor {
       }
 
       if ($target_block instanceof ContextAwarePluginInterface) {
-        $context_mapping = $form_state->getValue(['target_block', 'config', 'context_mapping']) ?? [];
-        $target_block->setContextMapping($context_mapping);
+        $context_mapping = $form_state->getValue(['target_block', 'config', 'context_mapping']);
+        // When the proxy is configured inside Layout Builder, the inner
+        // context_mapping element is intentionally not rendered (LB owns it
+        // at the root). In that case the submitted value is NULL and we
+        // must NOT clobber an existing saved mapping with an empty array.
+        if ($context_mapping !== NULL) {
+          $target_block->setContextMapping($context_mapping);
+        }
       }
 
       // Persist the unwrapped target plugin configuration.

--- a/tests/src/Kernel/ProxyBlockContextDefinitionsTest.php
+++ b/tests/src/Kernel/ProxyBlockContextDefinitionsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\proxy_block\Kernel;
+
+use Drupal\Component\Plugin\Exception\ContextException;
+use Drupal\Core\Plugin\Context\ContextDefinitionInterface;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Kernel test for ProxyBlock context-definition mirroring.
+ *
+ * @group proxy_block
+ * @coversDefaultClass \Drupal\proxy_block\Plugin\Block\ProxyBlock
+ */
+final class ProxyBlockContextDefinitionsTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'field',
+    'text',
+    'block',
+    'proxy_block',
+    'proxy_block_test',
+  ];
+
+  /**
+   * Creates a ProxyBlock instance configured for a specific target.
+   */
+  private function createProxyBlock(string $target_id): object {
+    /** @var \Drupal\Core\Block\BlockManagerInterface $manager */
+    $manager = $this->container->get('plugin.manager.block');
+    return $manager->createInstance('proxy_block_proxy', [
+      'target_block' => [
+        'id' => $target_id,
+        'config' => [],
+      ],
+    ]);
+  }
+
+  /**
+   * Target-mirrored names are returned by getContextDefinitions().
+   *
+   * @covers ::getContextDefinitions
+   */
+  public function testGetContextDefinitionsMirrorsTarget(): void {
+    $proxy = $this->createProxyBlock('proxy_block_test_context_aware');
+    $definitions = $proxy->getContextDefinitions();
+
+    $this->assertArrayHasKey('node', $definitions, 'Target node context is mirrored.');
+    $this->assertArrayHasKey('user', $definitions, 'Target user context is mirrored.');
+    $this->assertInstanceOf(ContextDefinitionInterface::class, $definitions['node']);
+    $this->assertInstanceOf(ContextDefinitionInterface::class, $definitions['user']);
+    $this->assertSame('entity:node', $definitions['node']->getDataType());
+    $this->assertSame('entity:user', $definitions['user']->getDataType());
+  }
+
+  /**
+   * With no target configured, only parent definitions are returned.
+   *
+   * @covers ::getContextDefinitions
+   */
+  public function testGetContextDefinitionsWithoutTarget(): void {
+    $proxy = $this->createProxyBlock('');
+    $definitions = $proxy->getContextDefinitions();
+
+    $this->assertArrayNotHasKey('node', $definitions);
+    $this->assertArrayNotHasKey('user', $definitions);
+  }
+
+  /**
+   * Tests that getContextDefinition() resolves through the merged map.
+   *
+   * @covers ::getContextDefinition
+   */
+  public function testGetContextDefinitionResolvesTargetMirrored(): void {
+    $proxy = $this->createProxyBlock('proxy_block_test_context_aware');
+
+    $node_def = $proxy->getContextDefinition('node');
+    $user_def = $proxy->getContextDefinition('user');
+
+    $this->assertInstanceOf(ContextDefinitionInterface::class, $node_def);
+    $this->assertInstanceOf(ContextDefinitionInterface::class, $user_def);
+    $this->assertSame('entity:node', $node_def->getDataType());
+    $this->assertSame('entity:user', $user_def->getDataType());
+  }
+
+  /**
+   * Unknown names fall through to parent and throw ContextException.
+   *
+   * @covers ::getContextDefinition
+   */
+  public function testGetContextDefinitionUnknownThrows(): void {
+    $proxy = $this->createProxyBlock('proxy_block_test_context_aware');
+
+    $this->expectException(ContextException::class);
+    $proxy->getContextDefinition('definitely_not_a_real_context');
+  }
+
+  /**
+   * Stale target id (deleted plugin) degrades to parent definitions.
+   *
+   * @covers ::getContextDefinitions
+   */
+  public function testGetContextDefinitionsWithStaleTarget(): void {
+    $proxy = $this->createProxyBlock('this_plugin_does_not_exist');
+    $definitions = $proxy->getContextDefinitions();
+
+    $this->assertIsArray($definitions);
+    $this->assertArrayNotHasKey('node', $definitions);
+  }
+
+}

--- a/tests/src/Unit/ProxyBlockRendererTest.php
+++ b/tests/src/Unit/ProxyBlockRendererTest.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\proxy_block\Unit;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Block\BlockManagerInterface;
+use Drupal\Core\Cache\CacheableDependencyInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\proxy_block\Service\ProxyBlockRenderer;
+use Drupal\proxy_block\Service\TargetBlockCacheManager;
+use Drupal\proxy_block\Service\TargetBlockContextManager;
+use Drupal\proxy_block\Service\TargetBlockFactory;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Unit tests for the ProxyBlockRenderer service.
+ *
+ * @coversDefaultClass \Drupal\proxy_block\Service\ProxyBlockRenderer
+ * @group proxy_block
+ */
+final class ProxyBlockRendererTest extends UnitTestCase {
+
+  /**
+   * Mock target block factory.
+   */
+  private TargetBlockFactory|MockObject $targetBlockFactory;
+
+  /**
+   * Mock context manager.
+   */
+  private TargetBlockContextManager|MockObject $contextManager;
+
+  /**
+   * Mock cache manager.
+   */
+  private TargetBlockCacheManager|MockObject $cacheManager;
+
+  /**
+   * Mock block manager.
+   */
+  private BlockManagerInterface|MockObject $blockManager;
+
+  /**
+   * Mock current user.
+   */
+  private AccountProxyInterface|MockObject $currentUser;
+
+  /**
+   * Mock request stack.
+   */
+  private RequestStack|MockObject $requestStack;
+
+  /**
+   * Mock logger.
+   */
+  private LoggerInterface|MockObject $logger;
+
+  /**
+   * The renderer under test.
+   */
+  private ProxyBlockRenderer $renderer;
+
+  /**
+   * Stand-in for the proxy plugin's cache-bubbling identity.
+   */
+  private CacheableDependencyInterface|MockObject $proxy;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->targetBlockFactory = $this->createMock(TargetBlockFactory::class);
+    $this->contextManager = $this->createMock(TargetBlockContextManager::class);
+    $this->cacheManager = $this->createMock(TargetBlockCacheManager::class);
+    $this->blockManager = $this->createMock(BlockManagerInterface::class);
+    $this->currentUser = $this->createMock(AccountProxyInterface::class);
+    $this->requestStack = $this->createMock(RequestStack::class);
+    $this->logger = $this->createMock(LoggerInterface::class);
+
+    $this->renderer = new ProxyBlockRenderer(
+      $this->targetBlockFactory,
+      $this->contextManager,
+      $this->cacheManager,
+      $this->blockManager,
+      $this->currentUser,
+      $this->requestStack,
+      $this->logger,
+    );
+
+    $this->renderer->setStringTranslation($this->getStringTranslationStub());
+
+    $this->proxy = $this->createMock(CacheableDependencyInterface::class);
+  }
+
+  /**
+   * Shortcut: invokes render() with sensible defaults.
+   */
+  private function callRender(array $configuration): array {
+    return $this->renderer->render(
+      $configuration,
+      [],
+      [],
+      [],
+      0,
+      'proxy_block_proxy',
+      $this->proxy,
+    );
+  }
+
+  /**
+   * @covers ::render
+   */
+  public function testRenderWithNoTargetBlockReturnsEmpty(): void {
+    $config = ['target_block' => ['id' => '']];
+
+    $this->targetBlockFactory
+      ->expects($this->once())
+      ->method('getTargetBlock')
+      ->with($config)
+      ->willReturn(NULL);
+
+    $this->assertEquals([], $this->callRender($config));
+  }
+
+  /**
+   * @covers ::render
+   */
+  public function testRenderWithAccessDeniedReturnsEmptyMarkup(): void {
+    $config = ['target_block' => ['id' => 'system_branding_block']];
+    $target_block = $this->createMock(BlockBase::class);
+
+    $this->targetBlockFactory->method('getTargetBlock')->willReturn($target_block);
+    $this->requestStack->method('getCurrentRequest')->willReturn(NULL);
+    $this->cacheManager->method('getCacheContexts')->willReturn([]);
+    $this->cacheManager->method('getCacheTags')->willReturn([]);
+    $this->cacheManager->method('getCacheMaxAge')->willReturn(0);
+
+    $target_block
+      ->expects($this->once())
+      ->method('access')
+      ->with($this->currentUser, TRUE)
+      ->willReturn(AccessResult::forbidden());
+
+    $result = $this->callRender($config);
+
+    $this->assertSame('', $result['#markup']);
+    $this->assertArrayHasKey('#cache', $result);
+  }
+
+  /**
+   * @covers ::render
+   */
+  public function testRenderWithAccessAllowedBubblesCache(): void {
+    $config = ['target_block' => ['id' => 'system_branding_block']];
+    $target_block = $this->createMock(BlockBase::class);
+
+    $this->targetBlockFactory->method('getTargetBlock')->willReturn($target_block);
+    $this->requestStack->method('getCurrentRequest')->willReturn(NULL);
+
+    $target_block->method('access')->willReturn(AccessResult::allowed());
+    $target_block->method('build')->willReturn(['#markup' => 'rendered']);
+
+    $this->cacheManager
+      ->expects($this->once())
+      ->method('bubbleTargetBlockCacheMetadata');
+
+    $result = $this->callRender($config);
+
+    $this->assertEquals(['#markup' => 'rendered'], $result);
+  }
+
+  /**
+   * @covers ::render
+   * @covers ::isLayoutBuilderAdminRoute
+   * @covers ::buildLayoutBuilderAdminPreview
+   */
+  public function testRenderInLayoutBuilderAdminMode(): void {
+    $config = ['target_block' => ['id' => 'system_branding_block']];
+    $target_block = $this->createMock(BlockBase::class);
+
+    $this->targetBlockFactory->method('getTargetBlock')->willReturn($target_block);
+    $this->cacheManager->method('getCacheContexts')->willReturn([]);
+    $this->cacheManager->method('getCacheTags')->willReturn([]);
+    $this->cacheManager->method('getCacheMaxAge')->willReturn(0);
+
+    $request = $this->createMock(Request::class);
+    $request->method('getPathInfo')->willReturn('/admin/structure/types/article/display/default/layout');
+    $request->query = new ParameterBag();
+    $this->requestStack->method('getCurrentRequest')->willReturn($request);
+
+    $this->blockManager
+      ->expects($this->once())
+      ->method('getDefinition')
+      ->with('system_branding_block', FALSE)
+      ->willReturn(['admin_label' => 'Site branding']);
+
+    $result = $this->callRender($config);
+
+    $this->assertStringContainsString('Proxy Block:', $result['#markup']);
+    $this->assertStringContainsString('Site branding', $result['#markup']);
+  }
+
+  /**
+   * @covers ::collectCacheContexts
+   */
+  public function testCollectCacheContexts(): void {
+    $config = ['target_block' => ['id' => 'x']];
+    $target = $this->createMock(BlockBase::class);
+    $this->targetBlockFactory->method('getTargetBlock')->willReturn($target);
+    $this->cacheManager
+      ->expects($this->once())
+      ->method('getCacheContexts')
+      ->with($target, ['parent'])
+      ->willReturn(['parent', 'route']);
+
+    $this->assertEquals(['parent', 'route'], $this->renderer->collectCacheContexts($config, ['parent']));
+  }
+
+  /**
+   * @covers ::collectCacheTags
+   */
+  public function testCollectCacheTagsAppendsProxyTag(): void {
+    $config = ['target_block' => ['id' => 'x']];
+    $target = $this->createMock(BlockBase::class);
+    $this->targetBlockFactory->method('getTargetBlock')->willReturn($target);
+    $this->cacheManager
+      ->expects($this->once())
+      ->method('getCacheTags')
+      ->with($target, ['parent'])
+      ->willReturn(['parent', 'config:y']);
+
+    $result = $this->renderer->collectCacheTags($config, ['parent'], 'proxy_block_proxy');
+
+    $this->assertContains('proxy_block_proxy:proxy_block_proxy', $result);
+  }
+
+  /**
+   * @covers ::collectCacheMaxAge
+   */
+  public function testCollectCacheMaxAge(): void {
+    $config = ['target_block' => ['id' => 'x']];
+    $target = $this->createMock(BlockBase::class);
+    $this->targetBlockFactory->method('getTargetBlock')->willReturn($target);
+    $this->cacheManager
+      ->expects($this->once())
+      ->method('getCacheMaxAge')
+      ->with($target, 0)
+      ->willReturn(60);
+
+    $this->assertEquals(60, $this->renderer->collectCacheMaxAge($config, 0));
+  }
+
+  /**
+   * @covers ::resolveTargetPluginDefinition
+   */
+  public function testResolveTargetPluginDefinitionMemoizes(): void {
+    $config = ['target_block' => ['id' => 'x']];
+
+    $this->blockManager
+      ->expects($this->once())
+      ->method('getDefinition')
+      ->with('x', FALSE)
+      ->willReturn(['admin_label' => 'X']);
+
+    $first = $this->renderer->resolveTargetPluginDefinition($config);
+    $second = $this->renderer->resolveTargetPluginDefinition($config);
+
+    $this->assertSame($first, $second);
+    $this->assertEquals(['admin_label' => 'X'], $first);
+  }
+
+  /**
+   * @covers ::resolveTargetPluginDefinition
+   */
+  public function testResolveTargetPluginDefinitionWithEmptyTargetReturnsNull(): void {
+    $this->blockManager
+      ->expects($this->never())
+      ->method('getDefinition');
+
+    $this->assertNull($this->renderer->resolveTargetPluginDefinition(['target_block' => ['id' => '']]));
+  }
+
+  /**
+   * @covers ::resolveTargetPluginDefinition
+   */
+  public function testResolveTargetPluginDefinitionCachesNullLookup(): void {
+    $config = ['target_block' => ['id' => 'stale']];
+
+    $this->blockManager
+      ->expects($this->once())
+      ->method('getDefinition')
+      ->with('stale', FALSE)
+      ->willReturn(NULL);
+
+    $this->assertNull($this->renderer->resolveTargetPluginDefinition($config));
+    $this->assertNull($this->renderer->resolveTargetPluginDefinition($config));
+  }
+
+}

--- a/tests/src/Unit/ProxyBlockTest.php
+++ b/tests/src/Unit/ProxyBlockTest.php
@@ -152,7 +152,7 @@ final class ProxyBlockTest extends ProxyBlockUnitTestBase {
     $this->formProcessor
       ->expects($this->once())
       ->method('buildTargetBlockConfigurationForm')
-      ->with('system_branding_block', $expected_config)
+      ->with('system_branding_block', $expected_config, $form_state)
       ->willReturn(['#markup' => 'Config form']);
 
     $result = $proxy_block_with_config->blockForm($form, $form_state);
@@ -200,7 +200,7 @@ final class ProxyBlockTest extends ProxyBlockUnitTestBase {
     $this->formProcessor
       ->expects($this->once())
       ->method('validateTargetBlock')
-      ->with($form_state, $expected_config);
+      ->with($form, $form_state, $expected_config);
 
     $this->proxyBlock->blockValidate($form, $form_state);
   }
@@ -211,12 +211,13 @@ final class ProxyBlockTest extends ProxyBlockUnitTestBase {
   public function testBlockSubmit(): void {
     $form = [];
     $form_state = $this->createMock(FormStateInterface::class);
-    $expected_config = ['target_block' => ['id' => 'test_block']];
+    $existing_config = $this->proxyBlock->getConfiguration();
+    $expected_config = ['target_block' => ['id' => 'test_block', 'config' => []]];
 
     $this->formProcessor
       ->expects($this->once())
       ->method('submitTargetBlock')
-      ->with($form_state)
+      ->with($form, $form_state, $existing_config)
       ->willReturn($expected_config);
 
     $this->proxyBlock->blockSubmit($form, $form_state);

--- a/tests/src/Unit/ProxyBlockTest.php
+++ b/tests/src/Unit/ProxyBlockTest.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\proxy_block\Unit;
 
-use Drupal\Core\Access\AccessResult;
-use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\proxy_block\Plugin\Block\ProxyBlock;
+use Drupal\proxy_block\Service\ProxyBlockRenderer;
+use Drupal\proxy_block\Service\TargetBlockFormProcessor;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Unit tests for ProxyBlock plugin.
+ *
+ * The plugin itself is now a thin shell that delegates form, render, and
+ * cache responsibilities to two services. These tests verify the
+ * delegations; the actual render/cache pipelines are covered by
+ * ProxyBlockRendererTest and the per-service tests.
  *
  * @coversDefaultClass \Drupal\proxy_block\Plugin\Block\ProxyBlock
  * @group proxy_block
@@ -18,38 +24,44 @@ use Drupal\proxy_block\Plugin\Block\ProxyBlock;
 final class ProxyBlockTest extends ProxyBlockUnitTestBase {
 
   /**
-   * The proxy block instance.
+   * Mock form processor.
    */
-  private ProxyBlock $proxyBlock;
+  private TargetBlockFormProcessor|MockObject $formProcessorMock;
+
+  /**
+   * Mock renderer.
+   */
+  private ProxyBlockRenderer|MockObject $rendererMock;
+
+  /**
+   * Builds a ProxyBlock with the given configuration and the shared mocks.
+   */
+  private function makeProxyBlock(array $configuration = []): ProxyBlock {
+    return new ProxyBlock(
+      $configuration,
+      'proxy_block_proxy',
+      ['admin_label' => 'Proxy Block', 'provider' => 'proxy_block'],
+      $this->formProcessorMock,
+      $this->rendererMock,
+    );
+  }
 
   /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
     parent::setUp();
-
-    $this->proxyBlock = new ProxyBlock(
-      [],
-      'proxy_block_proxy',
-      ['admin_label' => 'Proxy Block', 'provider' => 'proxy_block'],
-      $this->blockManager,
-      $this->currentUser,
-      $this->requestStack,
-      $this->targetBlockFactory,
-      $this->formProcessor,
-      $this->cacheManager,
-      $this->contextManager,
-      $this->logger
-    );
+    $this->formProcessorMock = $this->createMock(TargetBlockFormProcessor::class);
+    $this->rendererMock = $this->createMock(ProxyBlockRenderer::class);
   }
 
   /**
    * @covers ::defaultConfiguration
    */
   public function testDefaultConfiguration(): void {
-    $result = $this->proxyBlock->defaultConfiguration();
+    $proxy = $this->makeProxyBlock();
+    $result = $proxy->defaultConfiguration();
 
-    // Test the specific proxy_block additions.
     $this->assertArrayHasKey('target_block', $result);
     $this->assertEquals(['id' => NULL, 'config' => []], $result['target_block']);
   }
@@ -60,62 +72,31 @@ final class ProxyBlockTest extends ProxyBlockUnitTestBase {
   public function testBlockFormBasicStructure(): void {
     $form = [];
     $form_state = $this->createMock(FormStateInterface::class);
+    $proxy = $this->makeProxyBlock();
 
-    $block_definitions = $this->createCommonBlockDefinitions(FALSE);
-
-    $this->blockManager
+    $this->formProcessorMock
       ->expects($this->once())
-      ->method('getDefinitions')
-      ->willReturn($block_definitions);
+      ->method('getAvailableBlockOptions')
+      ->with('proxy_block_proxy')
+      ->willReturn([
+        'system_branding_block' => 'Site branding',
+        'user_login_block' => 'User login',
+      ]);
 
-    $this->formProcessor
+    $this->formProcessorMock
       ->expects($this->once())
       ->method('getSelectedTargetFromFormState')
       ->with($form_state)
       ->willReturn(NULL);
 
-    $result = $this->proxyBlock->blockForm($form, $form_state);
+    $result = $proxy->blockForm($form, $form_state);
 
     $this->assertArrayHasKey('target_block', $result);
-    $this->assertArrayHasKey('id', $result['target_block']);
-    $this->assertArrayHasKey('config', $result['target_block']);
-
     $this->assertEquals('select', $result['target_block']['id']['#type']);
-    $this->assertInstanceOf('Drupal\Core\StringTranslation\TranslatableMarkup', $result['target_block']['id']['#title']);
-    $this->assertTranslatableMarkup($result['target_block']['id']['#title'], 'Target Block');
-
     $options = $result['target_block']['id']['#options'];
     $this->assertArrayHasKey('', $options);
     $this->assertArrayHasKey('system_branding_block', $options);
-    $this->assertArrayHasKey('user_login_block', $options);
     $this->assertArrayNotHasKey('proxy_block_proxy', $options);
-  }
-
-  /**
-   * @covers ::blockForm
-   */
-  public function testBlockFormExcludesSelf(): void {
-    $form = [];
-    $form_state = $this->createMock(FormStateInterface::class);
-
-    $block_definitions = $this->createCommonBlockDefinitions(FALSE);
-
-    $this->blockManager
-      ->expects($this->once())
-      ->method('getDefinitions')
-      ->willReturn($block_definitions);
-
-    $this->formProcessor
-      ->expects($this->once())
-      ->method('getSelectedTargetFromFormState')
-      ->with($form_state)
-      ->willReturn(NULL);
-
-    $result = $this->proxyBlock->blockForm($form, $form_state);
-
-    $options = $result['target_block']['id']['#options'];
-    $this->assertArrayNotHasKey('proxy_block_proxy', $options);
-    $this->assertArrayHasKey('system_branding_block', $options);
   }
 
   /**
@@ -125,43 +106,28 @@ final class ProxyBlockTest extends ProxyBlockUnitTestBase {
     $form = [];
     $form_state = $this->createMock(FormStateInterface::class);
     $config = ['target_block' => ['id' => 'system_branding_block', 'config' => []]];
+    $proxy = $this->makeProxyBlock($config);
+    $expected_config = $proxy->getConfiguration();
 
-    $this->blockManager
+    $this->formProcessorMock
       ->expects($this->once())
-      ->method('getDefinitions')
-      ->willReturn($this->createCommonBlockDefinitions());
+      ->method('getAvailableBlockOptions')
+      ->willReturn(['system_branding_block' => 'Site branding']);
 
-    $proxy_block_with_config = new ProxyBlock(
-      $config,
-      'proxy_block_proxy',
-      ['admin_label' => 'Proxy Block', 'provider' => 'proxy_block'],
-      $this->blockManager,
-      $this->currentUser,
-      $this->requestStack,
-      $this->targetBlockFactory,
-      $this->formProcessor,
-      $this->cacheManager,
-      $this->contextManager,
-      $this->logger
-    );
-
-    $expected_config = $proxy_block_with_config->getConfiguration();
-
-    $this->formProcessor
+    $this->formProcessorMock
       ->expects($this->once())
       ->method('getSelectedTargetFromFormState')
       ->with($form_state)
       ->willReturn(['id' => 'system_branding_block']);
 
-    $this->formProcessor
+    $this->formProcessorMock
       ->expects($this->once())
       ->method('buildTargetBlockConfigurationForm')
       ->with('system_branding_block', $expected_config, $form_state)
       ->willReturn(['#markup' => 'Config form']);
 
-    $result = $proxy_block_with_config->blockForm($form, $form_state);
+    $result = $proxy->blockForm($form, $form_state);
 
-    $this->assertArrayHasKey('#markup', $result['target_block']['config']);
     $this->assertEquals('Config form', $result['target_block']['config']['#markup']);
   }
 
@@ -177,17 +143,12 @@ final class ProxyBlockTest extends ProxyBlockUnitTestBase {
       ],
     ];
     $form_state = $this->createMock(FormStateInterface::class);
-
-    $triggering_element = [
-      '#array_parents' => ['settings', 'target_block', 'id'],
-    ];
-
     $form_state
       ->expects($this->once())
       ->method('getTriggeringElement')
-      ->willReturn($triggering_element);
+      ->willReturn(['#array_parents' => ['settings', 'target_block', 'id']]);
 
-    $result = $this->proxyBlock->targetBlockAjaxCallback($form, $form_state);
+    $result = $this->makeProxyBlock()->targetBlockAjaxCallback($form, $form_state);
 
     $this->assertEquals(['#markup' => 'target config'], $result);
   }
@@ -195,251 +156,152 @@ final class ProxyBlockTest extends ProxyBlockUnitTestBase {
   /**
    * @covers ::blockValidate
    */
-  public function testBlockValidate(): void {
+  public function testBlockValidateDelegates(): void {
     $form = [];
     $form_state = $this->createMock(FormStateInterface::class);
+    $proxy = $this->makeProxyBlock();
 
-    $expected_config = $this->proxyBlock->getConfiguration();
-
-    $this->formProcessor
+    $this->formProcessorMock
       ->expects($this->once())
       ->method('validateTargetBlock')
-      ->with($form, $form_state, $expected_config);
+      ->with($form, $form_state, $proxy->getConfiguration());
 
-    $this->proxyBlock->blockValidate($form, $form_state);
+    $proxy->blockValidate($form, $form_state);
   }
 
   /**
    * @covers ::blockSubmit
    */
-  public function testBlockSubmit(): void {
+  public function testBlockSubmitDelegates(): void {
     $form = [];
     $form_state = $this->createMock(FormStateInterface::class);
-    $existing_config = $this->proxyBlock->getConfiguration();
-    $expected_config = ['target_block' => ['id' => 'test_block', 'config' => []]];
+    $proxy = $this->makeProxyBlock();
+    $existing_config = $proxy->getConfiguration();
+    $new_config = ['target_block' => ['id' => 'test_block', 'config' => []]];
 
-    $this->formProcessor
+    $this->formProcessorMock
       ->expects($this->once())
       ->method('submitTargetBlock')
       ->with($form, $form_state, $existing_config)
-      ->willReturn($expected_config);
+      ->willReturn($new_config);
 
-    $this->proxyBlock->blockSubmit($form, $form_state);
+    $proxy->blockSubmit($form, $form_state);
 
-    $this->assertEquals($expected_config, $this->proxyBlock->getConfiguration());
+    $this->assertEquals($new_config, $proxy->getConfiguration());
   }
 
   /**
    * @covers ::build
    */
-  public function testBuildWithNoTargetBlock(): void {
-    $expected_config = $this->proxyBlock->getConfiguration();
+  public function testBuildDelegatesToRenderer(): void {
+    $proxy = $this->makeProxyBlock();
+    $rendered = ['#markup' => 'rendered'];
 
-    $this->targetBlockFactory
+    $this->rendererMock
       ->expects($this->once())
-      ->method('getTargetBlock')
-      ->with($expected_config)
-      ->willReturn(NULL);
+      ->method('render')
+      ->with(
+        $proxy->getConfiguration(),
+        $this->isType('array'),
+        $this->isType('array'),
+        $this->isType('array'),
+        $this->isType('int'),
+        'proxy_block_proxy',
+        $proxy,
+      )
+      ->willReturn($rendered);
 
-    $result = $this->proxyBlock->build();
-
-    $this->assertEquals([], $result);
-  }
-
-  /**
-   * @covers ::build
-   */
-  public function testBuildInLayoutBuilderAdminMode(): void {
-    $config = ['target_block' => ['id' => 'system_branding_block']];
-
-    $target_block = $this->createMock(BlockBase::class);
-    $request = $this->createLayoutBuilderAdminRequest();
-
-    $this->requestStack
-      ->expects($this->once())
-      ->method('getCurrentRequest')
-      ->willReturn($request);
-
-    $this->blockManager
-      ->expects($this->once())
-      ->method('getDefinition')
-      ->with('system_branding_block')
-      ->willReturn($this->createSystemBrandingDefinition());
-
-    $proxy_block = new ProxyBlock(
-      $config,
-      'proxy_block_proxy',
-      ['admin_label' => 'Proxy Block', 'provider' => 'proxy_block'],
-      $this->blockManager,
-      $this->currentUser,
-      $this->requestStack,
-      $this->targetBlockFactory,
-      $this->formProcessor,
-      $this->cacheManager,
-      $this->contextManager,
-      $this->logger
-    );
-
-    $expected_config = $proxy_block->getConfiguration();
-
-    $this->targetBlockFactory
-      ->expects($this->exactly(4))
-      ->method('getTargetBlock')
-      ->with($expected_config)
-      ->willReturn($target_block);
-
-    $result = $proxy_block->build();
-
-    $this->assertArrayHasKey('#markup', $result);
-    $this->assertStringContainsString('Proxy Block:', $result['#markup']);
-    $this->assertStringContainsString('layout-builder-block', $result['#markup']);
-    $this->assertArrayHasKey('#cache', $result);
-  }
-
-  /**
-   * @covers ::build
-   */
-  public function testBuildWithAccessDenied(): void {
-    $target_block = $this->createMock(BlockBase::class);
-    $access_result = AccessResult::forbidden();
-    $expected_config = $this->proxyBlock->getConfiguration();
-
-    $this->targetBlockFactory
-      ->expects($this->exactly(4))
-      ->method('getTargetBlock')
-      ->with($expected_config)
-      ->willReturn($target_block);
-
-    $this->requestStack
-      ->expects($this->once())
-      ->method('getCurrentRequest')
-      ->willReturn(NULL);
-
-    $target_block
-      ->expects($this->once())
-      ->method('access')
-      ->with($this->currentUser, TRUE)
-      ->willReturn($access_result);
-
-    $result = $this->proxyBlock->build();
-
-    $this->assertArrayHasKey('#markup', $result);
-    $this->assertEquals('', $result['#markup']);
-    $this->assertArrayHasKey('#cache', $result);
-  }
-
-  /**
-   * @covers ::build
-   */
-  public function testBuildWithAccessAllowed(): void {
-    $target_block = $this->createMock(BlockBase::class);
-    $access_result = AccessResult::allowed();
-    $expected_build = ['#markup' => 'Target block content'];
-    $expected_config = $this->proxyBlock->getConfiguration();
-
-    $this->targetBlockFactory
-      ->expects($this->once())
-      ->method('getTargetBlock')
-      ->with($expected_config)
-      ->willReturn($target_block);
-
-    $this->requestStack
-      ->expects($this->once())
-      ->method('getCurrentRequest')
-      ->willReturn(NULL);
-
-    $target_block
-      ->expects($this->once())
-      ->method('access')
-      ->with($this->currentUser, TRUE)
-      ->willReturn($access_result);
-
-    $target_block
-      ->expects($this->once())
-      ->method('build')
-      ->willReturn($expected_build);
-
-    $this->cacheManager
-      ->expects($this->once())
-      ->method('bubbleTargetBlockCacheMetadata')
-      ->with($expected_build, $target_block, $this->proxyBlock);
-
-    $result = $this->proxyBlock->build();
-
-    $this->assertEquals($expected_build, $result);
+    $this->assertEquals($rendered, $proxy->build());
   }
 
   /**
    * @covers ::getCacheContexts
    */
-  public function testGetCacheContexts(): void {
-    $target_block = $this->createMock(BlockBase::class);
-    $expected_contexts = ['user.permissions', 'route'];
+  public function testGetCacheContextsDelegatesToRenderer(): void {
+    $proxy = $this->makeProxyBlock();
+    $expected = ['user.permissions', 'route'];
 
-    $this->targetBlockFactory
+    $this->rendererMock
       ->expects($this->once())
-      ->method('getTargetBlock')
-      ->with($this->proxyBlock->getConfiguration())
-      ->willReturn($target_block);
+      ->method('collectCacheContexts')
+      ->with($proxy->getConfiguration(), $this->isType('array'))
+      ->willReturn($expected);
 
-    $this->cacheManager
-      ->expects($this->once())
-      ->method('getCacheContexts')
-      ->with($target_block, $this->anything())
-      ->willReturn($expected_contexts);
-
-    $result = $this->proxyBlock->getCacheContexts();
-
-    $this->assertEquals($expected_contexts, $result);
+    $this->assertEquals($expected, $proxy->getCacheContexts());
   }
 
   /**
    * @covers ::getCacheTags
    */
-  public function testGetCacheTags(): void {
-    $target_block = $this->createMock(BlockBase::class);
-    $expected_tags = ['config:block.block.test', 'block_plugin:system_branding_block'];
+  public function testGetCacheTagsDelegatesToRenderer(): void {
+    $proxy = $this->makeProxyBlock();
+    $expected = ['config:foo', 'proxy_block_proxy:proxy_block_proxy'];
 
-    $this->targetBlockFactory
+    $this->rendererMock
       ->expects($this->once())
-      ->method('getTargetBlock')
-      ->with($this->proxyBlock->getConfiguration())
-      ->willReturn($target_block);
+      ->method('collectCacheTags')
+      ->with($proxy->getConfiguration(), $this->isType('array'), 'proxy_block_proxy')
+      ->willReturn($expected);
 
-    $this->cacheManager
-      ->expects($this->once())
-      ->method('getCacheTags')
-      ->with($target_block, $this->anything())
-      ->willReturn($expected_tags);
-
-    $result = $this->proxyBlock->getCacheTags();
-
-    $expected_tags[] = 'proxy_block_proxy:proxy_block_proxy';
-    $this->assertEquals($expected_tags, $result);
+    $this->assertEquals($expected, $proxy->getCacheTags());
   }
 
   /**
    * @covers ::getCacheMaxAge
    */
-  public function testGetCacheMaxAge(): void {
-    $target_block = $this->createMock(BlockBase::class);
-    $expected_max_age = 3600;
+  public function testGetCacheMaxAgeDelegatesToRenderer(): void {
+    $proxy = $this->makeProxyBlock();
 
-    $this->targetBlockFactory
+    $this->rendererMock
       ->expects($this->once())
-      ->method('getTargetBlock')
-      ->with($this->proxyBlock->getConfiguration())
-      ->willReturn($target_block);
+      ->method('collectCacheMaxAge')
+      ->with($proxy->getConfiguration(), $this->isType('int'))
+      ->willReturn(3600);
 
-    $this->cacheManager
+    $this->assertEquals(3600, $proxy->getCacheMaxAge());
+  }
+
+  /**
+   * @covers ::getContextDefinitions
+   */
+  public function testGetContextDefinitionsMirrorsResolvedTarget(): void {
+    $config = ['target_block' => ['id' => 'target_x', 'config' => []]];
+    $proxy = $this->makeProxyBlock($config);
+
+    $node_def = $this->createMockContextDefinition(TRUE, 'entity:node', 'Node');
+    $user_def = $this->createMockContextDefinition(FALSE, 'entity:user', 'User');
+
+    $this->rendererMock
       ->expects($this->once())
-      ->method('getCacheMaxAge')
-      ->with($target_block, $this->anything())
-      ->willReturn($expected_max_age);
+      ->method('resolveTargetPluginDefinition')
+      ->with($this->callback(static fn ($c) => ($c['target_block']['id'] ?? NULL) === 'target_x'))
+      ->willReturn([
+        'context_definitions' => [
+          'node' => $node_def,
+          'user' => $user_def,
+        ],
+      ]);
 
-    $result = $this->proxyBlock->getCacheMaxAge();
+    $definitions = $proxy->getContextDefinitions();
 
-    $this->assertEquals($expected_max_age, $result);
+    $this->assertArrayHasKey('node', $definitions);
+    $this->assertArrayHasKey('user', $definitions);
+  }
+
+  /**
+   * @covers ::getContextDefinitions
+   */
+  public function testGetContextDefinitionsWithoutResolvedTarget(): void {
+    $proxy = $this->makeProxyBlock();
+
+    $this->rendererMock
+      ->expects($this->once())
+      ->method('resolveTargetPluginDefinition')
+      ->willReturn(NULL);
+
+    $definitions = $proxy->getContextDefinitions();
+
+    $this->assertArrayNotHasKey('node', $definitions);
   }
 
 }

--- a/tests/src/Unit/ProxyBlockTest.php
+++ b/tests/src/Unit/ProxyBlockTest.php
@@ -37,7 +37,9 @@ final class ProxyBlockTest extends ProxyBlockUnitTestBase {
       $this->requestStack,
       $this->targetBlockFactory,
       $this->formProcessor,
-      $this->cacheManager
+      $this->cacheManager,
+      $this->contextManager,
+      $this->logger
     );
   }
 
@@ -138,7 +140,9 @@ final class ProxyBlockTest extends ProxyBlockUnitTestBase {
       $this->requestStack,
       $this->targetBlockFactory,
       $this->formProcessor,
-      $this->cacheManager
+      $this->cacheManager,
+      $this->contextManager,
+      $this->logger
     );
 
     $expected_config = $proxy_block_with_config->getConfiguration();
@@ -271,7 +275,9 @@ final class ProxyBlockTest extends ProxyBlockUnitTestBase {
       $this->requestStack,
       $this->targetBlockFactory,
       $this->formProcessor,
-      $this->cacheManager
+      $this->cacheManager,
+      $this->contextManager,
+      $this->logger
     );
 
     $expected_config = $proxy_block->getConfiguration();

--- a/tests/src/Unit/ProxyBlockUnitTestBase.php
+++ b/tests/src/Unit/ProxyBlockUnitTestBase.php
@@ -20,6 +20,7 @@ use Drupal\proxy_block\Service\TargetBlockFactory;
 use Drupal\proxy_block\Service\TargetBlockFormProcessor;
 use Drupal\Tests\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -73,6 +74,11 @@ abstract class ProxyBlockUnitTestBase extends UnitTestCase {
   protected TargetBlockContextManager|MockObject $contextManager;
 
   /**
+   * Mock logger.
+   */
+  protected LoggerInterface|MockObject $logger;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -112,6 +118,7 @@ abstract class ProxyBlockUnitTestBase extends UnitTestCase {
     $this->formProcessor = $this->createMock(TargetBlockFormProcessor::class);
     $this->cacheManager = $this->createMock(TargetBlockCacheManager::class);
     $this->contextManager = $this->createMock(TargetBlockContextManager::class);
+    $this->logger = $this->createMock(LoggerInterface::class);
   }
 
   /**

--- a/tests/src/Unit/TargetBlockContextManagerTest.php
+++ b/tests/src/Unit/TargetBlockContextManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\proxy_block\Unit;
 
+use Drupal\Component\Plugin\Exception\ContextException;
 use Drupal\Core\Plugin\Context\ContextDefinitionInterface;
 use Drupal\Core\Plugin\Context\ContextHandlerInterface;
 use Drupal\Core\Plugin\Context\ContextInterface;
@@ -46,7 +47,8 @@ class TargetBlockContextManagerTest extends ProxyBlockUnitTestBase {
 
     $this->testContextManager = new TestableTargetBlockContextManager(
       $this->contextRepository,
-      $this->contextHandler
+      $this->contextHandler,
+      $this->logger
     );
 
     $this->testContextManager->setStringTranslation($this->stringTranslation);
@@ -439,11 +441,16 @@ class TargetBlockContextManagerTest extends ProxyBlockUnitTestBase {
   }
 
   /**
-   * Tests applyContextsToTargetBlock with exception during context gathering.
+   * Tests that non-ContextException during gathering now propagates.
+   *
+   * The previous implementation wrapped the whole method in a broad
+   * catch(\Exception). It was deliberately tightened: only ContextException
+   * is swallowed during the context-handler application step; everything
+   * else surfaces so real bugs aren't silenced.
    *
    * @covers ::applyContextsToTargetBlock
    */
-  public function testApplyContextsToTargetBlockExceptionDuringGathering(): void {
+  public function testApplyContextsToTargetBlockExceptionDuringGatheringPropagates(): void {
     $target_block = $this->createMock(ContextAwarePluginInterface::class);
 
     $mock_view_mode_context = $this->createMock(ContextInterface::class);
@@ -453,20 +460,66 @@ class TargetBlockContextManagerTest extends ProxyBlockUnitTestBase {
       ->method('getAvailableContexts')
       ->willThrowException(new \Exception('Context repository error'));
 
-    // Should catch the exception and continue gracefully.
     $this->contextHandler
       ->expects($this->never())
       ->method('applyContextMapping');
 
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('Context repository error');
     $this->testContextManager->applyContextsToTargetBlock($target_block);
   }
 
   /**
-   * Tests applyContextsToTargetBlock with exception during context application.
+   * Tests that ContextException during application is logged and swallowed.
    *
    * @covers ::applyContextsToTargetBlock
    */
-  public function testApplyContextsToTargetBlockExceptionDuringApplication(): void {
+  public function testApplyContextsToTargetBlockContextExceptionDuringApplicationIsSwallowed(): void {
+    $context_definition = $this->createMock(ContextDefinitionInterface::class);
+    $context_definition->method('isRequired')
+      ->willReturn(TRUE);
+
+    $target_block = $this->createMock(ContextAwarePluginInterface::class);
+    $target_block->method('getContextDefinitions')
+      ->willReturn(['node' => $context_definition]);
+    $target_block->method('getContextMapping')
+      ->willReturn(['node' => 'current_node']);
+    $target_block->method('getPluginId')
+      ->willReturn('test_block');
+
+    $gathered_contexts = [
+      'current_node' => $this->createMock(ContextInterface::class),
+    ];
+
+    $mock_view_mode_context = $this->createMock(ContextInterface::class);
+    $this->testContextManager->setMockViewModeContext($mock_view_mode_context);
+
+    $this->contextRepository
+      ->method('getAvailableContexts')
+      ->willReturn(['current_node' => 'Node']);
+    $this->contextRepository
+      ->method('getRuntimeContexts')
+      ->willReturn($gathered_contexts);
+
+    $this->contextHandler
+      ->expects($this->once())
+      ->method('applyContextMapping')
+      ->willThrowException(new ContextException('Context application error'));
+
+    $this->logger
+      ->expects($this->once())
+      ->method('notice');
+
+    // Should catch the ContextException and continue gracefully.
+    $this->testContextManager->applyContextsToTargetBlock($target_block);
+  }
+
+  /**
+   * Tests that non-ContextException during application propagates.
+   *
+   * @covers ::applyContextsToTargetBlock
+   */
+  public function testApplyContextsToTargetBlockGenericExceptionDuringApplicationPropagates(): void {
     $context_definition = $this->createMock(ContextDefinitionInterface::class);
     $context_definition->method('isRequired')
       ->willReturn(TRUE);
@@ -494,9 +547,10 @@ class TargetBlockContextManagerTest extends ProxyBlockUnitTestBase {
     $this->contextHandler
       ->expects($this->once())
       ->method('applyContextMapping')
-      ->willThrowException(new \Exception('Context application error'));
+      ->willThrowException(new \RuntimeException('Unexpected error'));
 
-    // Should catch the exception and continue gracefully.
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Unexpected error');
     $this->testContextManager->applyContextsToTargetBlock($target_block);
   }
 

--- a/tests/src/Unit/TargetBlockFormProcessorTest.php
+++ b/tests/src/Unit/TargetBlockFormProcessorTest.php
@@ -77,7 +77,8 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->with($plugin_id, [])
       ->willReturn($target_block);
 
-    $result = $this->processor->buildTargetBlockConfigurationForm($plugin_id, $configuration);
+    $form_state = $this->createMock(FormStateInterface::class);
+    $result = $this->processor->buildTargetBlockConfigurationForm($plugin_id, $configuration, $form_state);
 
     $this->assertArrayHasKey('no_config', $result);
     $this->assertEquals('details', $result['no_config']['#type']);
@@ -121,7 +122,8 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->with($plugin_id, ['existing_config' => 'value'])
       ->willReturn($target_block);
 
-    $result = $this->processor->buildTargetBlockConfigurationForm($plugin_id, $configuration);
+    $form_state = $this->createMock(FormStateInterface::class);
+    $result = $this->processor->buildTargetBlockConfigurationForm($plugin_id, $configuration, $form_state);
 
     $this->assertArrayHasKey('block_config', $result);
     $this->assertEquals('details', $result['block_config']['#type']);
@@ -168,7 +170,8 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->with($plugin_id, [])
       ->willReturn($target_block);
 
-    $result = $this->processor->buildTargetBlockConfigurationForm($plugin_id, $configuration);
+    $form_state = $this->createMock(FormStateInterface::class);
+    $result = $this->processor->buildTargetBlockConfigurationForm($plugin_id, $configuration, $form_state);
 
     $this->assertArrayHasKey('no_config', $result);
     $this->assertArrayHasKey('context_mapping', $result);
@@ -212,7 +215,8 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->with($plugin_id, [])
       ->willReturn($target_block);
 
-    $result = $this->processor->buildTargetBlockConfigurationForm($plugin_id, $configuration);
+    $form_state = $this->createMock(FormStateInterface::class);
+    $result = $this->processor->buildTargetBlockConfigurationForm($plugin_id, $configuration, $form_state);
 
     $this->assertArrayHasKey('block_config', $result);
     $this->assertArrayHasKey('context_mapping', $result);
@@ -235,7 +239,8 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->with($plugin_id, [])
       ->willThrowException(new PluginException('Plugin not found'));
 
-    $result = $this->processor->buildTargetBlockConfigurationForm($plugin_id, $configuration);
+    $form_state = $this->createMock(FormStateInterface::class);
+    $result = $this->processor->buildTargetBlockConfigurationForm($plugin_id, $configuration, $form_state);
 
     $this->assertArrayHasKey('error', $result);
     $this->assertEquals('details', $result['error']['#type']);
@@ -261,7 +266,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'valid_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return ['some_config' => 'value'];
         }
         $this->fail('Unexpected getValue call with key: ' . print_r($key, TRUE));
@@ -279,7 +284,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->expects($this->never())
       ->method('setErrorByName');
 
-    $this->processor->validateTargetBlock($form_state, $configuration);
+    $this->processor->validateTargetBlock([], $form_state, $configuration);
 
     // Test passes if no exception is thrown and no error is set.
   }
@@ -300,7 +305,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'invalid_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return [];
         }
         $this->fail('Unexpected getValue call with key: ' . print_r($key, TRUE));
@@ -317,7 +322,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->method('setErrorByName')
       ->with('target_block][id', $this->isInstanceOf(TranslatableMarkup::class));
 
-    $this->processor->validateTargetBlock($form_state, $configuration);
+    $this->processor->validateTargetBlock([], $form_state, $configuration);
 
     // Test passes if error is set via setErrorByName.
   }
@@ -345,7 +350,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->expects($this->never())
       ->method('setErrorByName');
 
-    $this->processor->validateTargetBlock($form_state, $configuration);
+    $this->processor->validateTargetBlock([], $form_state, $configuration);
   }
 
   /**
@@ -368,7 +373,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'test_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return NULL;
         }
         $this->fail('Unexpected getValue call with key: ' . print_r($key, TRUE));
@@ -386,7 +391,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->expects($this->never())
       ->method('setErrorByName');
 
-    $this->processor->validateTargetBlock($form_state, $configuration);
+    $this->processor->validateTargetBlock([], $form_state, $configuration);
 
     // Test passes if no exception is thrown and fallback config is used.
   }
@@ -406,7 +411,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'simple_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return ['block_setting' => 'value'];
         }
         $this->fail('Unexpected getValue call with key: ' . print_r($key, TRUE));
@@ -429,7 +434,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->with('simple_block', ['block_setting' => 'value'])
       ->willReturn($target_block);
 
-    $result = $this->processor->submitTargetBlock($form_state);
+    $result = $this->processor->submitTargetBlock([], $form_state, []);
 
     $this->assertEquals('simple_block', $result['target_block']['id']);
     $this->assertEquals([
@@ -453,10 +458,9 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'configurable_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return ['user_setting' => 'user_value'];
         }
-        // @phpstan-ignore-next-line
         if ($key === ['target_block', 'config', 'context_mapping']) {
           return [];
         }
@@ -476,7 +480,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->with('configurable_block', ['user_setting' => 'user_value'])
       ->willReturn($target_block);
 
-    $result = $this->processor->submitTargetBlock($form_state);
+    $result = $this->processor->submitTargetBlock([], $form_state, []);
 
     $this->assertEquals('configurable_block', $result['target_block']['id']);
     $this->assertEquals([
@@ -500,10 +504,9 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'context_aware_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return ['setting' => 'value'];
         }
-        // @phpstan-ignore-next-line
         if ($key === ['target_block', 'config', 'context_mapping']) {
           return ['node' => 'current_node', 'user' => 'current_user'];
         }
@@ -527,7 +530,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->with('context_aware_block', ['setting' => 'value'])
       ->willReturn($target_block);
 
-    $result = $this->processor->submitTargetBlock($form_state);
+    $result = $this->processor->submitTargetBlock([], $form_state, []);
 
     $this->assertEquals('context_aware_block', $result['target_block']['id']);
     $this->assertEquals([
@@ -554,7 +557,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->expects($this->never())
       ->method('createInstance');
 
-    $result = $this->processor->submitTargetBlock($form_state);
+    $result = $this->processor->submitTargetBlock([], $form_state, []);
 
     $this->assertEquals('', $result['target_block']['id']);
     $this->assertEquals([], $result['target_block']['config']);
@@ -575,7 +578,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'invalid_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return ['setting' => 'value'];
         }
         $this->fail('Unexpected getValue call with key: ' . print_r($key, TRUE));
@@ -587,7 +590,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
       ->with('invalid_block', ['setting' => 'value'])
       ->willThrowException(new PluginException('Plugin not found'));
 
-    $result = $this->processor->submitTargetBlock($form_state);
+    $result = $this->processor->submitTargetBlock([], $form_state, []);
 
     $this->assertEquals('invalid_block', $result['target_block']['id']);
     $this->assertEquals([], $result['target_block']['config']);


### PR DESCRIPTION
Closes #30.

## Summary

Three commits on top of `main`:

1. **`4276e71` fix: integrate proxy block with Layout Builder** — initial LB integration. Exposes target plugin's context definitions on the proxy, forwards section-storage contexts to the target at render time, and suppresses the duplicate inner `context_mapping` element when LB owns it at the form root. Plumbs `SubformState` through validate/submit for the nested target sub-form.

2. **`0e28b65` fix: harden Layout Builder context handling** — audit + fixes informed by reviewing the sibling Lullabot `ab_tests` `ab_blocks` submodule:
   - `build()` context forwarding now wraps each `setContext()` in `try/catch (ContextException)` with a logged notice — one type mismatch can no longer tear down the render.
   - `TargetBlockFormProcessor::submitTargetBlock()` no longer clobbers a saved `context_mapping` with `[]` when the inner mapping element was intentionally suppressed inside LB.
   - `TargetBlockContextManager` narrows the broad `catch (\Exception)` to `catch (ContextException)` with logger notices; non-context errors propagate instead of being silently swallowed. Empty `else {}` and dead branches removed.
   - New `resolveRootEntityContext()` helper probes `['layout_builder.entity', 'entity', 'node']` and is used as a render-time fallback so targets needing the conventional `entity`/`node` name still resolve under LB.
   - Memoized `blockManager->getDefinition()` via a `getTargetPluginDefinition()` helper — `getContextDefinitions()` and the admin-mode label lookup now share a single call per build.
   - Injected `logger.channel.proxy_block` on `ProxyBlock` and `TargetBlockContextManager`.
   - New kernel test `ProxyBlockContextDefinitionsTest` covering target-mirrored names, missing/stale target, parent fallback, and unknown-name `ContextException`.

3. **`f98dcdc` refactor: slim ProxyBlock to delegate-only plugin** — splits responsibilities. New `ProxyBlockRenderer` service absorbs the `build()` pipeline, cache-metadata collection, target-plugin-definition memoization, LB admin-mode preview, and context forwarding (incl. root-entity fallback). `TargetBlockFormProcessor` gains `getAvailableBlockOptions()` so the plugin no longer depends on `BlockManagerInterface`. The `ProxyBlock` plugin constructor drops from **11 args to 5**: the 3 mandatory plugin args plus `TargetBlockFormProcessor` and `ProxyBlockRenderer`. The renderer takes plain arguments (config, contexts, parent cache contributions, plugin id, `CacheableDependencyInterface`) rather than the (final) plugin instance, so it can be unit-tested in isolation. New `ProxyBlockRendererTest`; `ProxyBlockTest` rewritten to assert pure delegation.

## Test plan

- [x] `vendor/bin/phpcs --standard=Drupal,DrupalPractice ... web/modules/contrib/proxy_block/{src,tests}` — clean.
- [x] `vendor/bin/phpstan analyze --configuration=web/modules/contrib/proxy_block/phpstan.neon web/modules/contrib/proxy_block/src` — no errors.
- [x] `vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/contrib/proxy_block/tests/src/Unit` — 82 tests, 214 assertions, all green.
- [ ] Kernel tests (require `SIMPLETEST_DB`): `vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/contrib/proxy_block/tests/src/Kernel` — to be run in CI.
- [ ] Manual: place a Proxy Block inside Layout Builder pointing at a context-aware target (e.g. a field block on a node display) and confirm the configure form has a single context-mapping element and the node context reaches the target at render time.
- [ ] Manual: place a Proxy Block via the block layout UI (`/admin/structure/block`) and confirm the inner context-mapping element is rendered and saved values are preserved when the same placement is later opened in LB.
- [ ] Manual: target a block whose required context cannot be satisfied — confirm the proxy logs a notice and renders empty instead of fatal-erroring.