### PR TITLE
fix: read block config from correct path

### DIFF
--- a/src/Service/TargetBlockFormProcessor.php
+++ b/src/Service/TargetBlockFormProcessor.php
@@ -121,7 +121,7 @@ class TargetBlockFormProcessor {
   public function validateTargetBlock(FormStateInterface $form_state, array $configuration): void {
     $target_block_plugin = $form_state->getValue(['target_block', 'id']);
     if (!empty($target_block_plugin)) {
-      $block_config = $form_state->getValue(['target_block', 'config']) ?? $configuration['target_block']['config'] ?? [];
+      $block_config = $form_state->getValue(['target_block', 'config', 'block_config']) ?? $configuration['target_block']['config'] ?? [];
 
       try {
         $this->blockManager->createInstance($target_block_plugin, $block_config);
@@ -149,7 +149,7 @@ class TargetBlockFormProcessor {
     $configuration['target_block']['id'] = $target_plugin_id;
 
     if (!empty($target_plugin_id)) {
-      $block_config = $form_state->getValue(['target_block', 'config']) ?? [];
+      $block_config = $form_state->getValue(['target_block', 'config', 'block_config']) ?? [];
 
       try {
         $target_block = $this->blockManager->createInstance($target_plugin_id, $block_config);

--- a/tests/src/Unit/TargetBlockFormProcessorTest.php
+++ b/tests/src/Unit/TargetBlockFormProcessorTest.php
@@ -261,7 +261,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'valid_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return ['some_config' => 'value'];
         }
         $this->fail('Unexpected getValue call with key: ' . print_r($key, TRUE));
@@ -300,7 +300,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'invalid_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return [];
         }
         $this->fail('Unexpected getValue call with key: ' . print_r($key, TRUE));
@@ -368,7 +368,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'test_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return NULL;
         }
         $this->fail('Unexpected getValue call with key: ' . print_r($key, TRUE));
@@ -406,7 +406,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'simple_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return ['block_setting' => 'value'];
         }
         $this->fail('Unexpected getValue call with key: ' . print_r($key, TRUE));
@@ -453,7 +453,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'configurable_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return ['user_setting' => 'user_value'];
         }
         // @phpstan-ignore-next-line
@@ -500,7 +500,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'context_aware_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return ['setting' => 'value'];
         }
         // @phpstan-ignore-next-line
@@ -575,7 +575,7 @@ class TargetBlockFormProcessorTest extends ProxyBlockUnitTestBase {
         if ($key === ['target_block', 'id']) {
           return 'invalid_block';
         }
-        if ($key === ['target_block', 'config']) {
+        if ($key === ['target_block', 'config', 'block_config']) {
           return ['setting' => 'value'];
         }
         $this->fail('Unexpected getValue call with key: ' . print_r($key, TRUE));


### PR DESCRIPTION
## Summary

- `validateTargetBlock()` and `submitTargetBlock()` read from `['target_block', 'config']` which returns the entire form wrapper (containing `block_config`, `context_mapping`, `no_config` keys)
- The actual block plugin configuration lives one level deeper at `['target_block', 'config', 'block_config']`
- The block plugin receives unrecognized wrapper keys via `setConfiguration()`, so nothing persists — reopening the form shows defaults

## Test plan

- [ ] Add a Proxy Block via Layout Builder, select a target block with configuration options (e.g. "Insider Exclusive Stories")
- [ ] Configure the block settings and save
- [ ] Re-open the block configuration and verify settings are preserved
- [ ] Run `vendor/bin/phpunit --debug -c web/core/phpunit.xml.dist web/modules/contrib/proxy_block/tests/src/Unit/TargetBlockFormProcessorTest.php` — all 19 tests pass