### PR TITLE
fix: proxy context-aware methods to target block

### DIFF
--- a/src/Plugin/Block/ProxyBlock.php
+++ b/src/Plugin/Block/ProxyBlock.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\proxy_block\Plugin\Block;
 
+use Drupal\Component\Plugin\Context\ContextInterface;
+use Drupal\Component\Plugin\Exception\ContextException;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
@@ -293,6 +295,71 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
   public function getCacheMaxAge(): int {
     $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
     return $this->cacheManager->getCacheMaxAge($target_block, parent::getCacheMaxAge());
+  }
+
+  public function getContextMapping() {
+    $context_mapping = $this->getConfiguration()['target_block']['config']['context_mapping'] ??= [];
+    return NestedArray::mergeDeep(parent::getContextMapping(), $context_mapping);
+  }
+
+  public function getContext($name) {
+    try {
+      return parent::getContext($name);
+    }
+    catch (ContextException $e) {
+      $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
+      if ($target_block instanceof ContextAwarePluginInterface) {
+        return $target_block->getContext($name);
+      }
+      throw $e;
+    }
+  }
+
+  public function setContextMapping(array $context_mapping) {
+    $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
+    if ($target_block instanceof ContextAwarePluginInterface) {
+      $target_block->setContextMapping($context_mapping);
+    }
+    return parent::setContextMapping($context_mapping);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setContext($name, ContextInterface $context) {
+    $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
+    if ($target_block instanceof ContextAwarePluginInterface) {
+      try {
+        $target_block->setContext($name, $context);
+      }
+      catch (ContextException $e) {
+      }
+    }
+    parent::setContext($name, $context);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContextDefinition($name) {
+    $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
+    if ($target_block instanceof ContextAwarePluginInterface) {
+      return $target_block->getContextDefinition('name');
+    }
+    throw new ContextException(sprintf("The %s context is not a valid context.", $name));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContextDefinitions() {
+    $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
+    if (!$target_block) {
+      return [];
+    }
+    return $target_block instanceof ContextAwarePluginInterface
+      ? $target_block->getContextDefinitions()
+      : $target_block->getPluginDefinition()['context_definition'] ?? [];
   }
 
 }

--- a/src/Plugin/Block/ProxyBlock.php
+++ b/src/Plugin/Block/ProxyBlock.php
@@ -345,7 +345,7 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
   public function getContextDefinition($name) {
     $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
     if ($target_block instanceof ContextAwarePluginInterface) {
-      return $target_block->getContextDefinition('name');
+      return $target_block->getContextDefinition($name);
     }
     throw new ContextException(sprintf("The %s context is not a valid context.", $name));
   }

--- a/src/Plugin/Block/ProxyBlock.php
+++ b/src/Plugin/Block/ProxyBlock.php
@@ -298,7 +298,7 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
   }
 
   public function getContextMapping() {
-    $context_mapping = $this->getConfiguration()['target_block']['config']['context_mapping'] ??= [];
+    $context_mapping = $this->getConfiguration()['target_block']['config']['context_mapping'] ?? [];
     return NestedArray::mergeDeep(parent::getContextMapping(), $context_mapping);
   }
 

--- a/src/Plugin/Block/ProxyBlock.php
+++ b/src/Plugin/Block/ProxyBlock.php
@@ -297,11 +297,9 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
     return $this->cacheManager->getCacheMaxAge($target_block, parent::getCacheMaxAge());
   }
 
-  public function getContextMapping() {
-    $context_mapping = $this->getConfiguration()['target_block']['config']['context_mapping'] ??= [];
-    return NestedArray::mergeDeep(parent::getContextMapping(), $context_mapping);
-  }
-
+  /**
+   * {@inheritdoc}
+   */
   public function getContext($name) {
     try {
       return parent::getContext($name);
@@ -315,6 +313,9 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function setContextMapping(array $context_mapping) {
     $target_block = $this->targetBlockFactory->getTargetBlock($this->getConfiguration());
     if ($target_block instanceof ContextAwarePluginInterface) {

--- a/src/Plugin/Block/ProxyBlock.php
+++ b/src/Plugin/Block/ProxyBlock.php
@@ -360,7 +360,7 @@ final class ProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
     }
     return $target_block instanceof ContextAwarePluginInterface
       ? $target_block->getContextDefinitions()
-      : $target_block->getPluginDefinition()['context_definition'] ?? [];
+      : $target_block->getPluginDefinition()['context_definitions'] ?? [];
   }
 
 }

--- a/src/Service/TargetBlockFormProcessor.php
+++ b/src/Service/TargetBlockFormProcessor.php
@@ -102,7 +102,7 @@ class TargetBlockFormProcessor {
             ],
           ],
           '#status_headings' => [
-            'warning' => t('Important'),
+            'warning' => $this->t('Important'),
           ],
         ];
       }

--- a/src/Service/TargetBlockFormProcessor.php
+++ b/src/Service/TargetBlockFormProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\proxy_block\Service;
 
+use Drupal\Component\Plugin\Definition\ContextAwarePluginDefinitionInterface;
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Form\FormState;
 use Drupal\Component\Plugin\Exception\PluginException;
@@ -87,9 +88,23 @@ class TargetBlockFormProcessor {
         ];
       }
 
-      if ($target_block instanceof ContextAwarePluginInterface) {
-        $gathered_contexts = $this->contextManager->getGatheredContexts();
-        $form_elements['context_mapping'] = $this->addContextAssignmentElement($target_block, $gathered_contexts);
+      $target_definition = $target_block->getPluginDefinition();
+      $context_definitions = $target_definition instanceof ContextAwarePluginDefinitionInterface
+        ? $target_definition->getContextDefinitions()
+        : $target_definition['context_definitions'] ?? [];
+      if (!empty($context_definitions)) {
+        $form_elements['context_mapping'] = [
+          '#theme' => 'status_messages',
+          '#message_list' => [
+            'warning' => [
+              $this->t('This block needs additional settings (context mapping). See them below.'),
+              $this->t('If you are just adding the block, the additional settings are not available. Save the block, and then update it to see the additional settings.'),
+            ],
+          ],
+          '#status_headings' => [
+            'warning' => t('Important'),
+          ],
+        ];
       }
 
       return $form_elements;


### PR DESCRIPTION
## Summary
- Override context-aware methods on `ProxyBlock` so context lookups, mappings, and definitions delegate to the configured target block.
- Replace the in-form context mapping element with a warning explaining that context mapping is only available after the block is saved.

## Test plan
- [ ] Place a context-aware block (e.g. one requiring a node context) via the proxy block in Layout Builder and confirm it renders with the correct context.
- [ ] Add a new proxy block targeting a context-aware block and verify the warning is displayed before save.
- [ ] Edit the saved proxy block and confirm the context mapping form becomes available.